### PR TITLE
do not clone master dolibarr branch

### DIFF
--- a/doc/Documentation SellYourSaas - Master and Deployment Servers - EN.asciidoc
+++ b/doc/Documentation SellYourSaas - Master and Deployment Servers - EN.asciidoc
@@ -691,12 +691,12 @@ On all servers (*Master and Deployment*):
 apt install git
 ---------------
 
-* Under the *admin* account, retrieve the sources of *Dolibarr* (v14 or +) to be placed in */home/admin/wwwroot/dolibarr*
+* Under the *admin* account, retrieve the sources of *Dolibarr* (v16 or +) to be placed in */home/admin/wwwroot/dolibarr*
 
 [source,bash]
 ---------------
 cd /home/admin/wwwroot
-git clone https://github.com/Dolibarr/dolibarr dolibarr --branch 15.0
+git clone https://github.com/Dolibarr/dolibarr dolibarr --branch x.y
 chown -R admin.admin /home/admin/wwwroot/dolibarr
 ---------------
 

--- a/doc/Documentation SellYourSaas - Master and Deployment Servers - EN.asciidoc
+++ b/doc/Documentation SellYourSaas - Master and Deployment Servers - EN.asciidoc
@@ -63,7 +63,7 @@ Funded by the Open Source companies https://www.dolicloud.com [DoliCloud] and ht
 * ...
      
 
-The project has been available as a community project since 2020 on GitHub: https://github.com/eldy/sellyoursaas
+The project has been available as a community project since 2020 on GitHub: https://github.com/dolicloud/sellyoursaas
 
 It is composed:
 
@@ -696,7 +696,7 @@ apt install git
 [source,bash]
 ---------------
 cd /home/admin/wwwroot
-git clone https://github.com/Dolibarr/dolibarr dolibarr
+git clone https://github.com/Dolibarr/dolibarr dolibarr --branch 15.0
 chown -R admin.admin /home/admin/wwwroot/dolibarr
 ---------------
 
@@ -705,7 +705,7 @@ chown -R admin.admin /home/admin/wwwroot/dolibarr
 [source,bash]
 ---------------
 cd /home/admin/wwwroot
-git clone https://github.com/eldy/sellyoursaas dolibarr_sellyoursaas
+git clone https://github.com/dolicloud/sellyoursaas dolibarr_sellyoursaas 
 ---------------
 
 

--- a/doc/Documentation SellYourSaas - Master and Deployment Servers - FR.asciidoc
+++ b/doc/Documentation SellYourSaas - Master and Deployment Servers - FR.asciidoc
@@ -636,7 +636,7 @@ apt install git
 [source,bash]
 ---------------
 cd /home/admin/wwwroot
-git clone https://github.com/Dolibarr/dolibarr dolibarr --branch 15.0
+git clone https://github.com/Dolibarr/dolibarr dolibarr --branch x.y
 chown -R admin.admin /home/admin/wwwroot/dolibarr
 ---------------
 

--- a/doc/Documentation SellYourSaas - Master and Deployment Servers - FR.asciidoc
+++ b/doc/Documentation SellYourSaas - Master and Deployment Servers - FR.asciidoc
@@ -62,7 +62,7 @@ Financé par les sociétés Open Source https://www.dolicloud.com[DoliCloud] et 
     * ... 
      
 
-Le projet est disponible de manière communautaire depuis 2020 sur GitHub: https://github.com/eldy/sellyoursaas
+Le projet est disponible de manière communautaire depuis 2020 sur GitHub: https://github.com/dolicloud/sellyoursaas
 
 Il est composé:
 
@@ -636,7 +636,7 @@ apt install git
 [source,bash]
 ---------------
 cd /home/admin/wwwroot
-git clone https://github.com/Dolibarr/dolibarr dolibarr
+git clone https://github.com/Dolibarr/dolibarr dolibarr --branch 15.0
 chown -R admin.admin /home/admin/wwwroot/dolibarr
 ---------------
 
@@ -645,7 +645,7 @@ chown -R admin.admin /home/admin/wwwroot/dolibarr
 [source,bash]
 ---------------
 cd /home/admin/wwwroot
-git clone https://github.com/eldy/sellyoursaas dolibarr_sellyoursaas
+git clone https://github.com/dolicloud/sellyoursaas dolibarr_sellyoursaas
 ---------------
 
 


### PR DESCRIPTION
Update github URI + add git clone option to get only stable branch (for example 15.0)