### PR TITLE
FIX: missing htdocs/ in target path for rsync command (for restoring programs)

### DIFF
--- a/core/lib/dolicloud.lib.php
+++ b/core/lib/dolicloud.lib.php
@@ -312,7 +312,7 @@ function getListOfLinks($object, $lastloginadmin, $lastpassadmin)
 	$links.='<br>';
 
 	// Rsync to Restore Program directory
-	$sftprestorestring='rsync -n -v -a --exclude \'conf.php\' --exclude \'*.cache\' htdocs/* '.$object->username_os.'@'.$object->hostname_os.':'.$object->database_db.'/';
+	$sftprestorestring='rsync -n -v -a --exclude \'conf.php\' --exclude \'*.cache\' htdocs/* '.$object->username_os.'@'.$object->hostname_os.':'.$object->database_db.'/htdocs/';
 	$links.='<span class="fa fa-terminal"></span> ';
 	$links.='Rsync to copy/overwrite application dir';
 	$links.='<span class="opacitymedium"> (remove -n to execute really)</span>:<br>';


### PR DESCRIPTION
Without it, files end up in the parent directory of the intended target.

More explicit instructions could be useful too (such as which directory the command should be run from), but this is already very helpful.