### PR TITLE
FIX: country detection (GeoIP) inoperative on registration pages

### DIFF
--- a/doc/Documentation SellYourSaas - Master and Deployment Servers - EN.asciidoc
+++ b/doc/Documentation SellYourSaas - Master and Deployment Servers - EN.asciidoc
@@ -1172,7 +1172,7 @@ You can create another virtual host for the HTTPS on port 443
    #php_admin_value sendmail_path "/usr/sbin/sendmail -t -i"
    #php_admin_value mail.force_extra_parameters "-f postmaster@mysaasdomainname.com"
    #php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f postmaster@mysaasdomainname.com"
-   php_admin_value open_basedir /tmp/:/home/admin/wwwroot/:/home/admin/tools/
+   php_admin_value open_basedir /tmp/:/home/admin/wwwroot/:/usr/share/GeoIP:/home/admin/tools/
 
    UseCanonicalName On
    ServerName   myaccount.mysaasdomainname.com

--- a/doc/Documentation SellYourSaas - Master and Deployment Servers - FR.asciidoc
+++ b/doc/Documentation SellYourSaas - Master and Deployment Servers - FR.asciidoc
@@ -1081,7 +1081,7 @@ Vous pouvez créer un autre virtual host pour le HTTPS port 443
    #php_admin_value sendmail_path "/usr/sbin/sendmail -t -i"
    #php_admin_value mail.force_extra_parameters "-f postmaster@mysaasdomainname.com"
    #php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f postmaster@mysaasdomainname.com"
-   php_admin_value open_basedir /tmp/:/home/admin/wwwroot/:/home/admin/tools/
+   php_admin_value open_basedir /tmp/:/home/admin/wwwroot/:/usr/share/GeoIP:/home/admin/tools/
 
    UseCanonicalName On
    ServerName   myaccount.mysaasdomainname.com


### PR DESCRIPTION
The Apache VirtualHost configuration for MyAccount as prescribed by the documentation does not allow the apache process to access /usr/share/GeoIP, where the geoip database is usually located.

Note: as an alternative to GeoIP, we could also use this bit of js for operators who don't want to use GeoIP, @eldy do you think it would be a good idea?

- Pros : works better for users with a VPN whose public IP is in a different country (unless the users deliberately change their timezone on the OS level or using a browser extension / feature).

- Cons : the server-side method using GeoIP is better for users without javascript or with older browsers that don't implement Intl.

I think both methods could even be used together (one being the fallback of the other).

```javascript
// time zone data from the Public Domain tzdatabase, endorsed by IETF and available at https://timezonedb.com/download
const tzdata2022 = {"Europe/Andorra": "AD","Asia/Dubai": "AE","Asia/Kabul": "AF", /* and so on …… */};

let tzAuto = '';

try { tzauto = Intl.DateTimeFormat().resolvedOptions().timeZone; } catch(error) {}
const countryAuto = tzdata2022[tzauto];

if (countryAuto) {
       $('#selectaddress_country').val(countryAuto).trigger('change');
}
```
