### PR TITLE
FIX counter-intuitiveness of SELLYOURSAAS_REGISTER_HIDE_PHONE

### DIFF
--- a/myaccount/register.php
+++ b/myaccount/register.php
@@ -496,7 +496,7 @@ llxHeader($head, $title, '', '', 0, 0, $arrayofjs, array(), '', 'register');
 						</div>
 					</div>
 				</div>
-				<?php if (getDolGlobalInt('SELLYOURSAAS_REGISTER_HIDE_PHONE')) { ?>
+				<?php if (! getDolGlobalInt('SELLYOURSAAS_REGISTER_HIDE_PHONE')) { ?>
 				<div class="horizontal-fld">
 					<div class='control-group'>
 						<label class='control-label' for='phone' trans='1'><span class="fa fa-phone opacityhigh"></span> <?php echo $langs->trans('Phone') ?></label>


### PR DESCRIPTION
The option name says "HIDE" but it currently shows the phone number when it is on (and hides it when the option is off).

Another possibility would be to rename the option `SELLYOURSAAS_REGISTER_SHOW_PHONE`, but I like it better with HIDE being the option.