### PR TITLE
NEW: Option to request acceptance of terms and conditions during sign-up of new user

### DIFF
--- a/myaccount/register.php
+++ b/myaccount/register.php
@@ -731,6 +731,20 @@ llxHeader($head, $title, '', '', 0, 0, $arrayofjs, array(), '', 'register');
 			<?php } ?>
 			<br>
 
+			<?php if (getDolGlobalString('SELLYOURSAAS_TERMSANDCONDITIONS')) { ?>
+				<!-- mandatory checkbox for terms and conditions -->
+				<section id="checkboxtermsandconditions">
+					<div class="group required">
+						<input type="checkbox" id="checkboxtermsandconditions" name="checkboxtermsandconditions" class="valignmiddle inline" style="margin-top: 0" value="1" required="1"<?php echo (GETPOST('checkboxtermsandconditions') ? ' checked="checked"' : ''); ?>>
+						<label for="checkboxtermsandconditions" class="valignmiddle small inline"><?php
+							$urlfortermofuse = 'https://www.'.getDolGlobalString(SELLYOURSAAS_MAIN_DOMAIN_NAME).'/'.getDolGlobalString(SELLYOURSAAS_TERMSANDCONDITIONS);
+							echo $langs->trans("WhenRegisteringYouAccept", $urlfortermofuse);
+							?></label>
+					</div>
+				</section>
+			<?php } ?>
+			<br>
+
 	   </div>
 
 		  <section id="formActions">


### PR DESCRIPTION
Currently, there is a mechanism to request acceptance of terms and conditions in a special way, if the host is dolicloud.com.

I added a generic mechanism, which will not affect the existing one:

If the variable SELLYOURSAAS_TERMSANDCONDITIONS is set with the name of the T&C page (e.g. terms.php), a checkbox is shown on the registration page to accept the terms and conditions and a link is provided to this page. Accepting this checkbox is mandatory to proceed, if it is shown. This is the last item on the page (after newsletter acceptance and optional non profit orga checkbox).

The message for the checkbox is stored under the key WhenRegisteringYouAccept (same as for the dolicloud specific mechanism to show T&C pages).

Screenshot (sorry, at the moment only in German available):

<img width="536" alt="image" src="https://user-images.githubusercontent.com/10772984/216756650-c40c48b6-384e-4adb-a6fb-473dba61ad9f.png">
