### PR TITLE
add usespecialdolibarrtagtodeploy option

### DIFF
--- a/etc/sellyoursaas.conf
+++ b/etc/sellyoursaas.conf
@@ -94,3 +94,8 @@ remotebackupdir=/mnt/diskbackup
 #chrootdir=/home/jail/chroot
 #privatejailtemplatename=privatejail
 #commonjailtemplatename=commonjail
+
+# Option for git_update_sources.sh script to stay on a special version (tag) of dolibarr sources
+# and be able to keep a beter control on relases / updates
+# this option could be 16.0 to stay on that version OR 16.0.4 for example if you wan't to be more restricted
+usespecialdolibarrtagtodeploy=16.0.4

--- a/scripts/git_update_sources.sh
+++ b/scripts/git_update_sources.sh
@@ -15,6 +15,7 @@ if [ "x$1" == "x" ]; then
 fi
 
 export usecompressformatforarchive=`grep '^usecompressformatforarchive=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
+export usespecialdolibarrtagtodeploy=`grep '^usespecialdolibarrtagtodeploy=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
 
 export currentpath=$(dirname "$0")
 
@@ -50,6 +51,11 @@ do
 	        	git pull
 	        fi
 	        echo Result of git pull = $?
+
+			if [ -n "${usespecialdolibarrtagtodeploy}" ]; then
+				echo "A special version of dolibarr is set (${usespecialdolibarrtagtodeploy}), checkout on it."
+				git checkout ${usespecialdolibarrtagtodeploy}
+			fi
 
 	    	git rev-parse HEAD > gitcommit.txt
 	    else


### PR DESCRIPTION
Here is an option you can use to stay on a special dolibarr tag or branch (script git_update_sources.sh)

The situation is you are on holidays and a new dolibarr version is published, you can't do the mysqldump of the new database and all new deployed dolibarr are blocked on "please upgrade your database" ... :-(