### PR TITLE
Fix incorrect empty string assignment to $error instead of 0

### DIFF
--- a/scripts/batch_customers.php
+++ b/scripts/batch_customers.php
@@ -466,7 +466,7 @@ if ($action == 'backup' || $action == 'backupdelete' ||$action == 'backuprsync' 
 
 $today=dol_now();
 
-$error=''; $errors=array();
+$error=0; $errors=array();
 $servicetouse=strtolower($conf->global->SELLYOURSAAS_NAME);
 
 if ($action == 'updatedatabase' || $action == 'updatestatsonly' || $action == 'updatecountsonly') {	// updatedatabase = updatestatsonly + updatecountsonly


### PR DESCRIPTION
Found as part of the investigation of the impact of https://wiki.php.net/rfc/saner-inc-dec-operators

This pair of assignments happens else where in this file and assigns ``$error`` to 0.