### PR TITLE
Fix: #281 (action upgrade also for change in minor version)

### DIFF
--- a/scripts/action_upgrade_instance.sh
+++ b/scripts/action_upgrade_instance.sh
@@ -282,7 +282,7 @@ if [[ "$mode" == "upgrade" ]];then
 
 		versionfrom=$lastversiondolibarrinstance
 		versionto=$(( $versionfrom + 1 ))
-		while [ $versionfrom -lt $laststableupgradeversion ]
+		while [ $versionfrom -le $laststableupgradeversion ]
 		do
 			if [ -f "$instancedir/documents/install.lock" ]
 			then
@@ -290,7 +290,7 @@ if [[ "$mode" == "upgrade" ]];then
 				rm "$instancedir/documents/install.lock"
 			fi
 
-			echo `date +'%Y-%m-%d %H:%M:%S'`" upgrade from version $versionfrom.0.0 to version $versionto.0.0"
+			echo `date +'%Y-%m-%d %H:%M:%S'`" upgrade from version $versionfrom.0.0 to version $versionto.0.0 (or last minor version)"
 
 			echo `date +'%Y-%m-%d %H:%M:%S'`" php upgrade.php $versionfrom.0.0 $versionto.0.0 >> $instancedir/documents/admin/temp/output.html"
 			php upgrade.php $versionfrom.0.0 $versionto.0.0 >> "$instancedir/documents/admin/temp/output.html"


### PR DESCRIPTION
Tested this with updating from one minor version to the next (i.e. from 16.0.3 to 16.0.4) and also updating from a minor to the next major version (form 16.0.4 to 17.0.0). In this case, technically there is one superfluous step going from 17.0.0 to 17.0.x, which is not doing any harm.

The logging is not quite right, because it does not explicitly print the minor version in the last run, but rather the next major version.