### PR TITLE
Fix fatal error while creating rec invoice after payment creation

### DIFF
--- a/myaccount/tpl/action_create_recinvoice_after_payment_creation.tpl.php
+++ b/myaccount/tpl/action_create_recinvoice_after_payment_creation.tpl.php
@@ -376,6 +376,9 @@ if (! $error) {
 				$savperm1 = $user->hasRight('facture', 'creer');
 				$savperm2 = $user->hasRight('facture', 'invoice_advance', 'validate');
 
+				if (!isset($user->rights->facture)) {
+					$user->rights->facture = new stdClass();
+				}
 				$user->rights->facture->creer = 1;	// Force permission to user to validate invoices because code may be executed by anonymous user
 				if (!$user->hasRight('facture', 'invoice_advance')) {
 					$user->rights->facture->invoice_advance = new stdClass();


### PR DESCRIPTION
A fatal error trigger when trying to set a field in a variable that is null