### PR TITLE
Fix: use specified port for remote backup server

### DIFF
--- a/scripts/backup_backups.php
+++ b/scripts/backup_backups.php
@@ -382,9 +382,9 @@ foreach ($SERVERDESTIARRAY as $servername) {
 	print dol_print_date(dol_now(), '%Y-%m-%d %H:%M:%S').' Do rsync of '.$DIRSOURCE1.' to remote '.$USER.'@'.$servername.':'.$DIRDESTI1."...\n";
 
 	if (empty($HISTODIR)) {
-		$command = "rsync ".$TESTN." -x --exclude-from=".$path."backup_backups.exclude ".$OPTIONS." ".$DIRSOURCE1."/* ".$USER."@".$servername.":".$DIRDESTI1;
+		$command = "rsync ".$TESTN." -e 'ssh -p ".$SERVPORTDESTI."' -x --exclude-from=".$path."backup_backups.exclude ".$OPTIONS." ".$DIRSOURCE1."/* ".$USER."@".$servername.":".$DIRDESTI1;
 	} else {
-		$command = "rsync ".$TESTN." -x --exclude-from=".$path."backup_backups.exclude ".$OPTIONS." --backup --backup-dir=".$DIRDESTI1."/backupold_".$HISTODIR." ".$DIRSOURCE1."/* ".$USER."@".$servername.":".$DIRDESTI1;
+		$command = "rsync ".$TESTN." -e 'ssh -p ".$SERVPORTDESTI."' -x --exclude-from=".$path."backup_backups.exclude ".$OPTIONS." --backup --backup-dir=".$DIRDESTI1."/backupold_".$HISTODIR." ".$DIRSOURCE1."/* ".$USER."@".$servername.":".$DIRDESTI1;
 	}
 	print dol_print_date(dol_now(), '%Y-%m-%d %H:%M:%S')." ".$command."\n";
 	$output = array();
@@ -518,9 +518,9 @@ if (!empty($instanceserver)) {
 						// Loop on each target server to make backup of backup of instance
 						foreach ($SERVERDESTIARRAY as $servername) {
 							if (empty($HISTODIR)) {
-								$command = "rsync ".$TESTN." -x --exclude-from=".$path."backup_backups.exclude ".$OPTIONS." ".$DIRSOURCE2."/".$obj->osu." ".$USER."@".$servername.":".$DIRDESTI2;
+								$command = "rsync ".$TESTN." -e 'ssh -p ".$SERVPORTDESTI."' -x --exclude-from=".$path."backup_backups.exclude ".$OPTIONS." ".$DIRSOURCE2."/".$obj->osu." ".$USER."@".$servername.":".$DIRDESTI2;
 							} else {
-								$command = "rsync ".$TESTN." -x --exclude-from=".$path."backup_backups.exclude ".$OPTIONS." --backup --backup-dir=".$DIRDESTI2."/backupold_".$HISTODIR." ".$DIRSOURCE2."/".$obj->osu." ".$USER."@".$servername.":".$DIRDESTI2;
+								$command = "rsync ".$TESTN." -e 'ssh -p ".$SERVPORTDESTI."' -x --exclude-from=".$path."backup_backups.exclude ".$OPTIONS." --backup --backup-dir=".$DIRDESTI2."/backupold_".$HISTODIR." ".$DIRSOURCE2."/".$obj->osu." ".$USER."@".$servername.":".$DIRDESTI2;
 							}
 							print dol_print_date(dol_now(), '%Y-%m-%d %H:%M:%S')." ".$command."\n";
 							$output = array();


### PR DESCRIPTION
The port specification from config file was not used for rsync with destination server.