### PR TITLE
FIX: with some versions of rsync, option --noatime fails

### DIFF
--- a/scripts/backup_backups.php
+++ b/scripts/backup_backups.php
@@ -270,10 +270,13 @@ if (empty($EMAILTO)) {
 }
 
 $OPTIONS = "-4 --prune-empty-dirs --stats -rlt --chmod=u=rwX";
-if ($DISTRIB_RELEASE == "20.04" || $DISTRIB_RELEASE == "22.04") {
-	$OPTIONS = $OPTIONS;
-} else {
+
+if (`rsync --help | grep -- --open-noatime`) {
+	$OPTIONS = $OPTIONS.' --open-noatime';
+} elseif (`rsync --help | grep -- --noatime`) {
 	$OPTIONS = $OPTIONS." --noatime";
+} else {
+    // no evidence rsync supports --noatime => we don't use the option at all
 }
 
 if ($RSYNCDELETE == 1) {


### PR DESCRIPTION
SellYourSaas seems to be aware of the issue already, but the current detection method (using Ubuntu version) is less reliable than using `rsync --help` and see if the option is described in the help text.

However, I am not used to executing shell commands from PHP and not comfortable with using the captured stdout. I'm open to better methods (like detecting rsync capabilities only once at install time, in an actual shell script, and storing the detection result in `sellyoursaas.conf` or any convenient place).