### PR TITLE
Fix support to prevent a bad workaround with non profit orga

### DIFF
--- a/myaccount/tpl/support.tpl.php
+++ b/myaccount/tpl/support.tpl.php
@@ -252,7 +252,7 @@ if ($sellyoursaassupporturl) {
 	print '</form>';
 
 
-	if (($action == 'presend' && GETPOST('supportchannel', 'alpha')) || getDolGlobalInt('SELLYOURSAAS_ONLY_NON_PROFIT_ORGA')) {
+	if ($action == 'presend' && GETPOST('supportchannel', 'alpha')) {
 		$trackid = '';
 		dol_init_file_process($upload_dir, $trackid);
 


### PR DESCRIPTION
Prevent the user to be on support page with all the fields filled after a email sent if the constant SELLYOURSAAS_ONLY_NON_PROFIT_ORGA is set