### PR TITLE
New datadog metrics for upgrade and ticket send on support

### DIFF
--- a/myaccount/index.php
+++ b/myaccount/index.php
@@ -818,6 +818,23 @@ if ($action == 'updateurl') {	// update URL from the tab "Domain"
 		if ($result) {
 			setEventMessages($langs->trans("TicketSent"), null, 'warnings');
 			$action = '';
+			if (! empty($conf->global->SELLYOURSAAS_DATADOG_ENABLED)) {
+				try {
+					dol_include_once('/sellyoursaas/core/includes/php-datadogstatsd/src/DogStatsd.php');
+	
+					$arrayconfig=array();
+					if (! empty($conf->global->SELLYOURSAAS_DATADOG_APIKEY)) {
+						$arrayconfig=array('apiKey' => $conf->global->SELLYOURSAAS_DATADOG_APIKEY, 'app_key' => $conf->global->SELLYOURSAAS_DATADOG_APPKEY);
+					}
+	
+					$statsd = new DataDog\DogStatsd($arrayconfig);
+	
+					$arraytags=null;
+					$statsd->increment('sellyoursaas.ticketsubmission', 1, $arraytags);
+				} catch (Exception $e) {
+					// Nothing done
+				}
+			}
 		} else {
 			setEventMessages($langs->trans("FailedToSentTicketPleaseTryLater").' '.$cmailfile->error, $cmailfile->errors, 'errors');
 			$action = 'presend';

--- a/myaccount/index.php
+++ b/myaccount/index.php
@@ -818,13 +818,13 @@ if ($action == 'updateurl') {	// update URL from the tab "Domain"
 		if ($result) {
 			setEventMessages($langs->trans("TicketSent"), null, 'warnings');
 			$action = '';
-			if (! empty($conf->global->SELLYOURSAAS_DATADOG_ENABLED)) {
+			if (getDolGlobalString("SELLYOURSAAS_DATADOG_ENABLED")) {
 				try {
 					dol_include_once('/sellyoursaas/core/includes/php-datadogstatsd/src/DogStatsd.php');
 	
 					$arrayconfig=array();
-					if (! empty($conf->global->SELLYOURSAAS_DATADOG_APIKEY)) {
-						$arrayconfig=array('apiKey' => $conf->global->SELLYOURSAAS_DATADOG_APIKEY, 'app_key' => $conf->global->SELLYOURSAAS_DATADOG_APPKEY);
+					if (getDolGlobalString("SELLYOURSAAS_DATADOG_APIKEY")) {
+						$arrayconfig=array('apiKey' => getDolGlobalString("SELLYOURSAAS_DATADOG_APIKEY"), 'app_key' => getDolGlobalString("SELLYOURSAAS_DATADOG_APPKEY"));
 					}
 	
 					$statsd = new DataDog\DogStatsd($arrayconfig);

--- a/myaccount/tpl/autoupgrade.tpl.php
+++ b/myaccount/tpl/autoupgrade.tpl.php
@@ -272,13 +272,13 @@ if ($action == "autoupgrade") {
 			$errortab[] = $langs->trans("ErrorOnUpgradeScript").' - exit code = '.$exitcode;
 			setEventMessages($langs->trans("ErrorOnUpgradeScript"), null, "errors");
 		} else {
-			if (! empty($conf->global->SELLYOURSAAS_DATADOG_ENABLED)) {
+			if (getDolGlobalString("SELLYOURSAAS_DATADOG_ENABLED")) {
 				try {
 					dol_include_once('/sellyoursaas/core/includes/php-datadogstatsd/src/DogStatsd.php');
 	
 					$arrayconfig=array();
-					if (! empty($conf->global->SELLYOURSAAS_DATADOG_APIKEY)) {
-						$arrayconfig=array('apiKey' => $conf->global->SELLYOURSAAS_DATADOG_APIKEY, 'app_key' => $conf->global->SELLYOURSAAS_DATADOG_APPKEY);
+					if (getDolGlobalString("SELLYOURSAAS_DATADOG_APIKEY")) {
+						$arrayconfig=array('apiKey' => getDolGlobalString("SELLYOURSAAS_DATADOG_APIKEY"), 'app_key' => getDolGlobalString("SELLYOURSAAS_DATADOG_APPKEY"));
 					}
 	
 					$statsd = new DataDog\DogStatsd($arrayconfig);

--- a/myaccount/tpl/autoupgrade.tpl.php
+++ b/myaccount/tpl/autoupgrade.tpl.php
@@ -271,6 +271,24 @@ if ($action == "autoupgrade") {
 			$errors++;
 			$errortab[] = $langs->trans("ErrorOnUpgradeScript").' - exit code = '.$exitcode;
 			setEventMessages($langs->trans("ErrorOnUpgradeScript"), null, "errors");
+		} else {
+			if (! empty($conf->global->SELLYOURSAAS_DATADOG_ENABLED)) {
+				try {
+					dol_include_once('/sellyoursaas/core/includes/php-datadogstatsd/src/DogStatsd.php');
+	
+					$arrayconfig=array();
+					if (! empty($conf->global->SELLYOURSAAS_DATADOG_APIKEY)) {
+						$arrayconfig=array('apiKey' => $conf->global->SELLYOURSAAS_DATADOG_APIKEY, 'app_key' => $conf->global->SELLYOURSAAS_DATADOG_APPKEY);
+					}
+	
+					$statsd = new DataDog\DogStatsd($arrayconfig);
+	
+					$arraytags=null;
+					$statsd->increment('sellyoursaas.upgradeinstance', 1, $arraytags);
+				} catch (Exception $e) {
+					// Nothing done
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Add 2 new metrics for datadog:
- When an instance is successfully upgraded
- When a ticket is successfully sent on support