### PR TITLE
Fix bug in creating custom URL for CMS websites with SellYourSaaS

### DIFF
--- a/myaccount/tpl/instances.tpl.php
+++ b/myaccount/tpl/instances.tpl.php
@@ -821,7 +821,7 @@ if (count($listofcontractid) == 0) {				// If all contracts were removed
 							$arraywebsitesenabled[$websiteref] = $websitecustomurl;
 						}
 					}
-					foreach ($listofwebsitestoactivate as $website) {
+					foreach ($websitestatic->records as $website) {
 						$isalreadyactivated = 0;
 						if (isset($arraywebsitesenabled[$website->ref])) {
 							$isalreadyactivated = 1;


### PR DESCRIPTION
After calling $websitestatic->fetchAll (line 795),  the variable $listofwebsitestoactivate contains the number of websites. The data of the websites, over which we need to iterate, is stored in the property $webistestatic->records.