### PR TITLE
PHP-FMP integration

### DIFF
--- a/scripts/action_deploy_undeploy.sh
+++ b/scripts/action_deploy_undeploy.sh
@@ -34,12 +34,22 @@ export PID=${$}
 export scriptdir=$(dirname $(realpath ${0}))
 
 # possibility to change the directory of vhostfile templates
+# possibility to use vhostfile templates associated to php-fpm mode with second priority
 templatesdir=`grep '^templatesdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
+phpfpm=`grep '^phpfpm=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
+phpversion=`grep '^phpversion=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
+localip=`grep '^localip=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
 if [[ "x$templatesdir" != "x" ]]; then
 	export vhostfile="$templatesdir/vhostHttps-sellyoursaas.template"
 	export vhostfilesuspended="$templatesdir/vhostHttps-sellyoursaas-suspended.template"
 	export vhostfilemaintenance="$templatesdir/vhostHttps-sellyoursaas-maintenance.template"
 	export fpmpoolfiletemplate="$templatesdir/osuxxx.template"
+elif [[ "x$phpfpm" != "x" ]]; then
+  export vhostfile="$scriptdir/templates/vhostHttps-phpfpm-sellyoursaas.template"
+	export vhostfilesuspended="$scriptdir/templates/vhostHttps-phpfpm-sellyoursaas-suspended.template"
+	export vhostfilemaintenance="$scriptdir/templates/vhostHttps-phpfpm-sellyoursaas-maintenance.template"
+	export fpmpoolfiletemplate="$scriptdir/templates/phppool-phpfpm.template"
+	export fpmservicefiletemplate="$scriptdir/templates/poolservice-phpfpm.template"
 else
 	export vhostfile="$scriptdir/templates/vhostHttps-sellyoursaas.template"
 	export vhostfilesuspended="$scriptdir/templates/vhostHttps-sellyoursaas-suspended.template"
@@ -1079,6 +1089,10 @@ if [[ "$mode" == "deploy" || "$mode" == "deployall" ]]; then
 			  sed -e 's;__SELLYOURSAAS_LOGIN_FOR_SUPPORT__;$SELLYOURSAAS_LOGIN_FOR_SUPPORT;g' | \
 			  sed -e 's;#ErrorLog;$ErrorLog;g' | \
 			  sed -e 's;__webMyAccount__;$SELLYOURSAAS_ACCOUNT_URL;g' | \
+				sed -e 's;__phpversion__;$phpversion;g' | \
+				sed -e 's;__fqn__;$fqn;g' | \
+				sed -e 's;__instancename__;$instancename;g' | \
+				sed -e 's;__localip__;$localip;g' | \
 			  sed -e 's;__webAppPath__;$instancedir;g' > $apacheconf"
 	cat $vhostfile | sed -e "s/__webAppDomain__/$instancename.$domainname/g" | \
 			  sed -e "s/__webAppAliases__/$instancename.$domainname/g" | \
@@ -1096,6 +1110,10 @@ if [[ "$mode" == "deploy" || "$mode" == "deployall" ]]; then
 			  sed -e "s;__SELLYOURSAAS_LOGIN_FOR_SUPPORT__;$SELLYOURSAAS_LOGIN_FOR_SUPPORT;g" | \
 			  sed -e "s;#ErrorLog;$ErrorLog;g" | \
 			  sed -e "s;__webMyAccount__;$SELLYOURSAAS_ACCOUNT_URL;g" | \
+				sed -e "s;__phpversion__;$phpversion;g" | \
+				sed -e "s;__fqn__;$fqn;g" | \
+				sed -e "s;__instancename__;$instancename;g" | \
+				sed -e "s;__localip__;$localip;g" | \
 			  sed -e "s;__webAppPath__;$instancedir;g" > $apacheconf
 
 
@@ -1224,6 +1242,10 @@ if [[ "$mode" == "deploy" || "$mode" == "deployall" ]]; then
 				  sed -e 's;#ErrorLog;$ErrorLog;g' | \
 				  sed -e 's;__webMyAccount__;$SELLYOURSAAS_ACCOUNT_URL;g' | \
 				  sed -e 's;__webAppPath__;$instancedir;g' | \
+				  sed -e 's;__phpversion__;$phpversion;g' | \
+				  sed -e 's;__fqn__;$fqn;g' | \
+				  sed -e 's;__instancename__;$instancename;g' | \
+				  sed -e 's;__localip__;$localip;g' | \
 				  sed -e 's/with\.sellyoursaas\.com/$CERTIFFORCUSTOMDOMAIN/g' > $apacheconf"
 		cat $vhostfile | sed -e "s/__webAppDomain__/$customurl/g" | \
 				  sed -e "s/__webAppAliases__/$customurl/g" | \
@@ -1242,6 +1264,10 @@ if [[ "$mode" == "deploy" || "$mode" == "deployall" ]]; then
 				  sed -e "s;#ErrorLog;$ErrorLog;g" | \
 				  sed -e "s;__webMyAccount__;$SELLYOURSAAS_ACCOUNT_URL;g" | \
 				  sed -e "s;__webAppPath__;$instancedir;g" | \
+				  sed -e "s;__phpversion__;$phpversion;g" | \
+				  sed -e "s;__fqn__;$fqn;g" | \
+				  sed -e "s;__instancename__;$instancename;g" | \
+				  sed -e "s;__localip__;$localip;g" | \
 				  sed -e "s/with\.sellyoursaas\.com/$CERTIFFORCUSTOMDOMAIN/g" > $apacheconf
 
 
@@ -1251,9 +1277,11 @@ if [[ "$mode" == "deploy" || "$mode" == "deployall" ]]; then
 	
 	
 	# Deploy also the php fpm pool file from the scripts/templates/osuxxx.conf
-	# A link will also be created into /etc/php/x.x/fpm/pool.d/$fqn.conf to this fpm pool file $fqn.conf
-	export phpfpmconf="/etc/apache2/sellyoursaas-fpm-pool.d/$fqn.conf"
-	if [ -d /etc/apache2/sellyoursaas-fpm-pool.d ]; then
+	# A link will also be created into /etc/php/$phpversion/fpm/pool.d/$fqn.conf to this fpm pool file $fqn.conf
+	export phpfpmconf="/etc/php/$phpversion/fpm/pool.d/sellyoursaas/$fqn.phpfpm.conf"
+	export phpfpmservicename="sellyoursaas-php$phpversion-fpm-$fqn.service"
+	export phpfpmservice="/etc/systemd/system/$phpfpmservicename"
+	if [ -d /etc/php/$phpversion/fpm/pool.d/sellyoursaas ]; then
 		echo `date +'%Y-%m-%d %H:%M:%S'`" ***** Create php fpm conf $phpfpmconf from $fpmpoolfiletemplate"
 		if [[ -s $phpfpmconf ]]
 		then
@@ -1277,6 +1305,10 @@ if [[ "$mode" == "deploy" || "$mode" == "deployall" ]]; then
 				  sed -e 's;__SELLYOURSAAS_LOGIN_FOR_SUPPORT__;$SELLYOURSAAS_LOGIN_FOR_SUPPORT;g' | \
 				  sed -e 's;#ErrorLog;$ErrorLog;g' | \
 				  sed -e 's;__webMyAccount__;$SELLYOURSAAS_ACCOUNT_URL;g' | \
+				  sed -e 's;__phpversion__;$phpversion;g' | \
+				  sed -e 's;__fqn__;$fqn;g' | \
+				  sed -e 's;__instancename__;$instancename;g' | \
+				  sed -e 's;__localip__;$localip;g' | \
 				  sed -e 's;__webAppPath__;$instancedir;g' > $phpfpmconf"
 		cat $fpmpoolfiletemplate | sed -e "s/__webAppDomain__/$instancename.$domainname/g" | \
 				  sed -e "s/__webAppAliases__/$instancename.$domainname/g" | \
@@ -1294,10 +1326,77 @@ if [[ "$mode" == "deploy" || "$mode" == "deployall" ]]; then
 				  sed -e "s;__SELLYOURSAAS_LOGIN_FOR_SUPPORT__;$SELLYOURSAAS_LOGIN_FOR_SUPPORT;g" | \
 				  sed -e "s;#ErrorLog;$ErrorLog;g" | \
 				  sed -e "s;__webMyAccount__;$SELLYOURSAAS_ACCOUNT_URL;g" | \
+				  sed -e "s;__phpversion__;$phpversion;g" | \
+				  sed -e "s;__fqn__;$fqn;g" | \
+				  sed -e "s;__instancename__;$instancename;g" | \
+				  sed -e "s;__localip__;$localip;g" | \
 				  sed -e "s;__webAppPath__;$instancedir;g" > $phpfpmconf
+
+		echo `date +'%Y-%m-%d %H:%M:%S'`" ***** Create php fpm service $phpfpmservice from $fpmservicefiletemplate"
+		if [[ -s $phpfpmservice ]]
+		then
+			echo "Apache conf $phpfpmservice already exists, we delete it since it may be a file from an old instance with same name"
+			rm -f $phpfpmservice
+		fi
+
+		echo "cat $fpmservicefiletemplate | sed -e 's/__webAppDomain__/$instancename.$domainname/g' | \
+				  sed -e 's/__webAppAliases__/$instancename.$domainname/g' | \
+				  sed -e 's/__webAppLogName__/$instancename/g' | \
+	              sed -e 's/__webSSLCertificateCRT__/$webSSLCertificateCRT/g' | \
+	              sed -e 's/__webSSLCertificateKEY__/$webSSLCertificateKEY/g' | \
+	              sed -e 's/__webSSLCertificateIntermediate__/$webSSLCertificateIntermediate/g' | \
+				  sed -e 's/__webAdminEmail__/$EMAILFROM/g' | \
+				  sed -e 's/__osUsername__/$osusername/g' | \
+				  sed -e 's/__osGroupname__/$osusername/g' | \
+				  sed -e 's;__osUserPath__;$targetdir/$osusername/$dbname;g' | \
+				  sed -e 's;__VirtualHostHead__;$VIRTUALHOSTHEAD;g' | \
+				  sed -e 's;__AllowOverride__;$ALLOWOVERRIDE;g' | \
+				  sed -e 's;__IncludeFromContract__;$INCLUDEFROMCONTRACT;g' | \
+				  sed -e 's;__SELLYOURSAAS_LOGIN_FOR_SUPPORT__;$SELLYOURSAAS_LOGIN_FOR_SUPPORT;g' | \
+				  sed -e 's;#ErrorLog;$ErrorLog;g' | \
+				  sed -e 's;__webMyAccount__;$SELLYOURSAAS_ACCOUNT_URL;g' | \
+				  sed -e 's;__phpversion__;$phpversion;g' | \
+				  sed -e 's;__fqn__;$fqn;g' | \
+				  sed -e 's;__instancename__;$instancename;g' | \
+				  sed -e 's;__localip__;$localip;g' | \
+				  sed -e 's;__webAppPath__;$instancedir;g' > $phpfpmservice"
+		cat $fpmservicefiletemplate | sed -e "s/__webAppDomain__/$instancename.$domainname/g" | \
+				  sed -e "s/__webAppAliases__/$instancename.$domainname/g" | \
+				  sed -e "s/__webAppLogName__/$instancename/g" | \
+	              sed -e "s/__webSSLCertificateCRT__/$webSSLCertificateCRT/g" | \
+	              sed -e "s/__webSSLCertificateKEY__/$webSSLCertificateKEY/g" | \
+	              sed -e "s/__webSSLCertificateIntermediate__/$webSSLCertificateIntermediate/g" | \
+				  sed -e "s/__webAdminEmail__/$EMAILFROM/g" | \
+				  sed -e "s/__osUsername__/$osusername/g" | \
+				  sed -e "s/__osGroupname__/$osusername/g" | \
+				  sed -e "s;__osUserPath__;$targetdir/$osusername/$dbname;g" | \
+				  sed -e "s;__VirtualHostHead__;$VIRTUALHOSTHEAD;g" | \
+				  sed -e "s;__AllowOverride__;$ALLOWOVERRIDE;g" | \
+				  sed -e "s;__IncludeFromContract__;$INCLUDEFROMCONTRACT;g" | \
+				  sed -e "s;__SELLYOURSAAS_LOGIN_FOR_SUPPORT__;$SELLYOURSAAS_LOGIN_FOR_SUPPORT;g" | \
+				  sed -e "s;#ErrorLog;$ErrorLog;g" | \
+				  sed -e "s;__webMyAccount__;$SELLYOURSAAS_ACCOUNT_URL;g" | \
+				  sed -e "s;__phpversion__;$phpversion;g" | \
+				  sed -e "s;__fqn__;$fqn;g" | \
+				  sed -e "s;__instancename__;$instancename;g" | \
+				  sed -e "s;__localip__;$localip;g" | \
+				  sed -e "s;__webAppPath__;$instancedir;g" > $phpfpmservice
+
+		echo `date +'%Y-%m-%d %H:%M:%S'`" ***** php-fpm service created. We start $phpfpmservice service"
+		systemctl daemon-reload
+    systemctl enable $phpfpmservicename
+		systemctl daemon-reload
+    systemctl restart $phpfpmservicename
+		if [[ "x$?" != "x0" ]]; then
+			echo Error when starting $phpfpmservicename
+			echo "Failed to deployall instance $instancename.$domainname with: Error when starting $phpfpmservicename" | mail -aFrom:$EMAILFROM -s "[Alert] Pb in deployment" $EMAILTO
+			sleep 1		# add a delay after an php$phpversion-fpm reload
+			exit 20
+		fi
+		sleep 1			# add a delay after an php$phpversion-fpm reload
+
 	fi
-	
-	
+
 	echo /usr/sbin/apache2ctl configtest
 	/usr/sbin/apache2ctl configtest
 	if [[ "x$?" != "x0" ]]; then

--- a/scripts/templates/phppool-phpfpm.template
+++ b/scripts/templates/phppool-phpfpm.template
@@ -1,0 +1,28 @@
+;----------------------------------------------------
+; php-fpm config file for a pool for sellyoursaas instances
+;
+; All apache virtual hosts of user osuxxx will use this same pool
+;----------------------------------------------------
+
+[__fqn__]
+
+user = __osUsername__
+group = __osGroupname__
+
+listen = /run/php/php__phpversion__-fpm-__fqn__.sock
+listen.owner = __osUsername__
+listen.group = __osGroupname__
+request_terminate_timeout = 0
+
+pm = dynamic
+pm.max_children = 50
+pm.start_servers = 5
+pm.min_spare_servers = 5
+pm.max_spare_servers = 35
+
+env[PATH] = /usr/local/bin:/usr/bin:/bin
+env[TMP] = /tmp
+env[TMPDIR] = /tmp
+env[TEMP] = /tmp
+
+php_admin_value[open_basedir] = __webAppPath__:/home/admin/wwwroot/dolibarr_sellyoursaas/scripts/:/tmp/:/usr/local/bin/

--- a/scripts/templates/poolservice-phpfpm.template
+++ b/scripts/templates/poolservice-phpfpm.template
@@ -1,0 +1,18 @@
+;----------------------------------------------------
+; php-fpm file for a pool service for sellyoursaas instances
+;
+;----------------------------------------------------
+
+[Unit]
+Description=PHP-FPM for __fqn__
+After=network.target
+
+[Service]
+Type=simple
+PIDFile=/run/php/php__phpversion__-fpm-__fqn__.pid
+ExecStart=/usr/sbin/php-fpm__phpversion__ --nodaemonize --fpm-config /etc/php/__phpversion__/fpm/pool.d/sellyoursaas/__fqn__.phpfpm.conf --allow-to-run-as-root
+ExecReload=/bin/kill -USR2 $MAINPID
+ExecStop=/bin/kill -QUIT $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/templates/vhostHttps-phpfpm-sellyoursaas-maintenance.template
+++ b/scripts/templates/vhostHttps-phpfpm-sellyoursaas-maintenance.template
@@ -1,0 +1,81 @@
+<VirtualHost *:443 *:80>
+        __VirtualHostHead__
+        
+        # Allow access to /tmp and sellyoursaas scripts for mails. Allow also access to user dir.
+        php_admin_value open_basedir /tmp/:/home/admin/wwwroot/dolibarr_sellyoursaas/scripts/:__webAppPath__/:/usr/local/bin/
+
+        ServerName __webAppDomain__
+        ServerAdmin __webAdminEmail__
+        ServerAlias __webAppAliases__
+        DocumentRoot __webAppPath__/htdocs
+
+        AddDefaultCharset UTF-8
+
+        # Need mpm-itk module
+        <IfModule mpm_itk_module>
+        AssignUserID __osUsername__ __osGroupname__
+        </IfModule>
+
+        <Directory "__webAppPath__/htdocs">
+        Require all granted
+		__AllowOverride__
+        Options -Indexes +FollowSymLinks
+        </Directory>
+
+        # Possible values include: debug, info, notice, warn, error, crit, alert, emerg.
+        LogLevel info
+
+        ErrorLog /var/log/apache2/apache_sellyoursaas_maintenance_error.log
+        #TransferLog /var/log/apache2/__webAppLogName___access_log
+        
+        # Compress returned resources of type php pages, text file export, css and javascript
+        AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css text/javascript application/javascript application/x-javascript
+
+        # Netscape 4.x has some problems...
+        BrowserMatch ^Mozilla/4 gzip-only-text/html
+
+        # Netscape 4.06-4.08 have some more problems
+        BrowserMatch ^Mozilla/4\.0[678] no-gzip
+
+        # MSIE masquerades as Netscape, but it is fine
+        BrowserMatch \bMSIE !no-gzip !gzip-only-text/html
+
+        # Make sure proxies don't deliver the wrong content
+        #Header append Vary User-Agent env=!dont-vary
+
+        DeflateFilterNote Input instream
+        DeflateFilterNote Output outstream
+        DeflateFilterNote Ratio ratio
+
+        #LogFormat '"%r" %{outstream}n/%{instream}n (%{ratio}n%%)' deflate
+        #CustomLog deflate_log deflate
+
+        #   SSL Engine Switch:
+        #   Enable/Disable SSL for this virtual host.
+        SSLEngine on
+
+
+        RewriteEngine   on
+        # This will enable the Rewrite capabilities
+        
+        RewriteCond     "%{HTTP_USER_AGENT}"   "!__SELLYOURSAAS_LOGIN_FOR_SUPPORT__"
+        RewriteRule     ^(.*)$ __webMyAccount__/maintenance.php?instance=%{SERVER_NAME} [L,R]
+		# This redirect to the maintenance page
+
+        <FilesMatch "\.(cgi|shtml|phtml|php)$">
+                SSLOptions +StdEnvVars
+        </FilesMatch>
+
+        BrowserMatch ".*MSIE.*" \
+                nokeepalive ssl-unclean-shutdown \
+                downgrade-1.0 force-response-1.0
+
+SSLCertificateFile /etc/apache2/__webSSLCertificateCRT__
+SSLCertificateKeyFile /etc/apache2/__webSSLCertificateKEY__
+SSLCertificateChainFile /etc/apache2/__webSSLCertificateIntermediate__
+SSLCACertificateFile /etc/apache2/__webSSLCertificateIntermediate__
+
+</VirtualHost>
+
+
+

--- a/scripts/templates/vhostHttps-phpfpm-sellyoursaas-suspended.template
+++ b/scripts/templates/vhostHttps-phpfpm-sellyoursaas-suspended.template
@@ -1,0 +1,80 @@
+<VirtualHost *:443 *:80>
+        __VirtualHostHead__
+        
+        # Allow access to /tmp and sellyoursaas scripts for mails. Allow also access to user dir.
+        php_admin_value open_basedir /tmp/:/home/admin/wwwroot/dolibarr_sellyoursaas/scripts/:__webAppPath__/:/usr/local/bin/
+
+        ServerName __webAppDomain__
+        ServerAdmin __webAdminEmail__
+        ServerAlias __webAppAliases__
+        DocumentRoot __webAppPath__/htdocs
+
+        AddDefaultCharset UTF-8
+
+        # Need mpm-itk module
+        <IfModule mpm_itk_module>
+        AssignUserID __osUsername__ __osGroupname__
+        </IfModule>
+
+        <Directory "__webAppPath__/htdocs">
+        Require all granted
+		__AllowOverride__
+        Options -Indexes +FollowSymLinks
+        </Directory>
+
+        # Possible values include: debug, info, notice, warn, error, crit, alert, emerg.
+        LogLevel info
+
+        ErrorLog /var/log/apache2/apache_sellyoursaas_suspended_error.log
+        #TransferLog /var/log/apache2/__webAppLogName___access_log
+        
+        # Compress returned resources of type php pages, text file export, css and javascript
+        AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css text/javascript application/javascript application/x-javascript
+
+        # Netscape 4.x has some problems...
+        BrowserMatch ^Mozilla/4 gzip-only-text/html
+
+        # Netscape 4.06-4.08 have some more problems
+        BrowserMatch ^Mozilla/4\.0[678] no-gzip
+
+        # MSIE masquerades as Netscape, but it is fine
+        BrowserMatch \bMSIE !no-gzip !gzip-only-text/html
+
+        # Make sure proxies don't deliver the wrong content
+        #Header append Vary User-Agent env=!dont-vary
+
+        DeflateFilterNote Input instream
+        DeflateFilterNote Output outstream
+        DeflateFilterNote Ratio ratio
+
+        #LogFormat '"%r" %{outstream}n/%{instream}n (%{ratio}n%%)' deflate
+        #CustomLog deflate_log deflate
+
+        #   SSL Engine Switch:
+        #   Enable/Disable SSL for this virtual host.
+        SSLEngine on
+
+
+        RewriteEngine   on
+        # This will enable the Rewrite capabilities
+        
+        RewriteRule     ^(.*)$ __webMyAccount__/suspended.php?instance=%{SERVER_NAME} [L,R]
+		# This redirect to the suspended page
+
+        <FilesMatch "\.(cgi|shtml|phtml|php)$">
+                SSLOptions +StdEnvVars
+        </FilesMatch>
+
+        BrowserMatch ".*MSIE.*" \
+                nokeepalive ssl-unclean-shutdown \
+                downgrade-1.0 force-response-1.0
+
+SSLCertificateFile /etc/apache2/__webSSLCertificateCRT__
+SSLCertificateKeyFile /etc/apache2/__webSSLCertificateKEY__
+SSLCertificateChainFile /etc/apache2/__webSSLCertificateIntermediate__
+SSLCACertificateFile /etc/apache2/__webSSLCertificateIntermediate__
+
+</VirtualHost>
+
+
+

--- a/scripts/templates/vhostHttps-phpfpm-sellyoursaas.template
+++ b/scripts/templates/vhostHttps-phpfpm-sellyoursaas.template
@@ -1,0 +1,102 @@
+<VirtualHost __localip__:443 __localip__:80>
+        __VirtualHostHead__
+        
+        <IfModule mod_apparmor.c>
+        AADefaultHatName sellyoursaas-instances
+        </IfModule>
+
+        ServerName __webAppDomain__
+        ServerAdmin __webAdminEmail__
+        ServerAlias __webAppAliases__
+        DocumentRoot __webAppPath__/htdocs
+
+        # Indiquer à Apache d'utiliser le socket de PHP-FPM spécifique
+        <FilesMatch \.php$>
+            SetEnv PHP_ADMIN_VALUE "php_admin_value[fpm.config] = /etc/php/__phpversion__/fpm/pool.d/sellyoursaas/__fqn__.phpfpm.conf"
+            SetHandler "proxy:unix:/run/php/php__phpversion__-fpm-__fqn__.sock|fcgi://localhost/"
+        </FilesMatch>
+
+        AddDefaultCharset UTF-8
+
+        # Need mpm-itk module
+        <IfModule mpm_itk_module>
+        	# MaxRequestWorkers = MaxClients
+        	# MaxClientsVHost is for vhost/itk only
+        	MaxClientsVHost 50
+
+        	AssignUserID __osUsername__ __osGroupname__
+        </IfModule>
+
+		# __ AllowOverride __ is defined on package.
+		# __ IncludeFromContract __ is defined on contract. 
+		# For example: "Require ip 1.2.3.4"
+		# or "IncludeOptional /etc/apache2/sellyoursaas-online/__webAppDomain__-directory-options.conf"
+        <Directory "__webAppPath__/htdocs">
+            __AllowOverride__
+            <RequireAll>
+                Require all granted
+                __IncludeFromContract__
+            </RequireAll>
+            Options -Indexes +FollowSymLinks
+        </Directory>
+
+        # Possible values include: debug, info, notice, warn, error, crit, alert, emerg.
+        LogLevel info
+
+        ErrorLog __osUserPath__/__webAppLogName___error.log
+        #TransferLog ${APACHE_LOG_DIR}/__webAppLogName___access_log
+        CustomLog ${APACHE_LOG_DIR}/other_vhosts_access.log vhost_combined
+        CustomLog ${APACHE_LOG_DIR}/other_vhosts_pid.log "%v:%p %h %P %t \"%r\" %>s %O"
+
+        # Compress returned resources of type php pages, text file export, css and javascript
+        AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css text/javascript application/javascript application/x-javascript
+
+        # Netscape 4.x has some problems...
+        BrowserMatch ^Mozilla/4 gzip-only-text/html
+
+        # Netscape 4.06-4.08 have some more problems
+        BrowserMatch ^Mozilla/4\.0[678] no-gzip
+
+        # MSIE masquerades as Netscape, but it is fine
+        BrowserMatch \bMSIE !no-gzip !gzip-only-text/html
+
+        # Make sure proxies don't deliver the wrong content
+        #Header append Vary User-Agent env=!dont-vary
+
+        #DeflateFilterNote Input instream
+        #DeflateFilterNote Output outstream
+        #DeflateFilterNote Ratio ratio
+        #LogFormat '"%r" %{outstream}n/%{instream}n (%{ratio}n%%)' deflate
+        #CustomLog deflate_log deflate
+
+        #   SSL Engine Switch:
+        #   Enable/Disable SSL for this virtual host.
+        SSLEngine on
+
+
+        RewriteEngine On
+        # This will enable the Rewrite capabilities
+		
+        RewriteCond %{HTTPS} !=on
+        # This checks to make sure the connection is not already HTTPS
+		
+        RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
+        # This rule will redirect users from their original location, to the same location but using HTTPS.
+        # i.e.  http://www.example.com/foo/ to https://www.example.com/foo/
+        # The leading slash is made optional so that this will work either in httpd.conf
+        # or .htaccess context
+
+
+        <FilesMatch "\.(cgi|shtml|phtml|php)$">
+                SSLOptions +StdEnvVars
+        </FilesMatch>
+
+        BrowserMatch ".*MSIE.*" nokeepalive ssl-unclean-shutdown downgrade-1.0 force-response-1.0
+
+		SSLCertificateFile __webSSLCertificateCRT__
+		SSLCertificateKeyFile __webSSLCertificateKEY__
+		SSLCertificateChainFile __webSSLCertificateIntermediate__
+		SSLCACertificateFile __webSSLCertificateIntermediate__
+
+
+</VirtualHost>


### PR DESCRIPTION
There is no easy way to install apache mod_php in ubuntu 24.04. So, it seems that mod_php is dying. To get Sellyoursaas working in this OS, we needed to switch to php-fpm.  

Beyond the needed code in deploy_undeploy.sh script, this includes adding new vitual host, pool and service templates.

Three new variables have been defined in sellyoursaas.conf : 
**phpfpm** : to indicate to deploy_undeploy.sh to deploy a virtual  host for php-fpm
**phpversion** : In the form x.y. It substitues __phpversion__ in commands referring to the php version
**localip** : To be compatible with web hosting control panels such as Virtualmin, the declaration of the created virtualhosts should be explicit. It may take the  value of 0 if we use no  web hosting control panel.

The virtual host template also includes 