### PR TITLE
Fix: Error generating certfile for website

### DIFF
--- a/scripts/action_website_instance.sh
+++ b/scripts/action_website_instance.sh
@@ -293,8 +293,8 @@ if [[ "$mode" == "deploywebsite" ]]; then
 		certbot certonly --webroot -w $instancedir/documents/website/$WEBSITENAME -d www.$CUSTOMDOMAIN
 		export certko=$?
 	else
-		echo certbot certonly --webroot -w $instancedir/website/$WEBSITENAME -d www.$CUSTOMDOMAIN -d $CUSTOMDOMAIN
-		certbot certonly --webroot -w $instancedir/website/$WEBSITENAME -d www.$CUSTOMDOMAIN -d $CUSTOMDOMAIN
+		echo certbot certonly --webroot -w $instancedir/documents/website/$WEBSITENAME -d www.$CUSTOMDOMAIN -d $CUSTOMDOMAIN
+		certbot certonly --webroot -w $instancedir/documents/website/$WEBSITENAME -d www.$CUSTOMDOMAIN -d $CUSTOMDOMAIN
 		export certko=$?
 	fi
 	


### PR DESCRIPTION
If the website name did not start with www. a wrong path was used (missing 'documents/' in filepath).