### PR TITLE
New hook delete support user

### DIFF
--- a/backoffice/instance_users.php
+++ b/backoffice/instance_users.php
@@ -349,7 +349,7 @@ if (empty($reshook)) {
 		$newdb = getDoliDBInstance($type_db, $hostname_db, $username_db, $password_db, $database_db, $port_db);
 
 		$parameters = array('newdb' => $newdb);
-		$reshook = $hookmanager->executeHooks('deleteSupportUser', $parameters, $object, $action);
+		$reshook = $hookmanager->executeHooks('sellYourSaasDeleteSupportUser', $parameters, $object, $action);
 		if ($reshook < 0) {
 			setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 		}

--- a/backoffice/instance_users.php
+++ b/backoffice/instance_users.php
@@ -350,6 +350,9 @@ if (empty($reshook)) {
 
 		$parameters = array('newdb' => $newdb);
 		$reshook = $hookmanager->executeHooks('deleteSupportUser', $parameters, $object, $action);
+		if ($reshook < 0) {
+			setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+		}
 
 		if (is_object($newdb)) {
 			$fordolibarr = 1;

--- a/backoffice/instance_users.php
+++ b/backoffice/instance_users.php
@@ -345,8 +345,6 @@ if (empty($reshook)) {
 			setEventMessages('Password for user <b>'.$loginforsupport.'</b> set to <b>'.$password.'</b>', null, 'warnings');
 		}
 	}
-
-
 	if ($action == "deletesupportuser") {
 		$newdb = getDoliDBInstance($type_db, $hostname_db, $username_db, $password_db, $database_db, $port_db);
 

--- a/backoffice/instance_users.php
+++ b/backoffice/instance_users.php
@@ -348,7 +348,7 @@ if (empty($reshook)) {
 	if ($action == "deletesupportuser") {
 		$newdb = getDoliDBInstance($type_db, $hostname_db, $username_db, $password_db, $database_db, $port_db);
 
-		$parameters = array('newdb'=>$newdb);
+		$parameters = array('newdb' => $newdb);
 		$reshook = $hookmanager->executeHooks('deleteSupportUser', $parameters, $object, $action);
 
 		if (is_object($newdb)) {

--- a/backoffice/instance_users.php
+++ b/backoffice/instance_users.php
@@ -345,8 +345,14 @@ if (empty($reshook)) {
 			setEventMessages('Password for user <b>'.$loginforsupport.'</b> set to <b>'.$password.'</b>', null, 'warnings');
 		}
 	}
+
+
 	if ($action == "deletesupportuser") {
 		$newdb = getDoliDBInstance($type_db, $hostname_db, $username_db, $password_db, $database_db, $port_db);
+
+		$parameters = array('newdb'=>$newdb);
+		$reshook = $hookmanager->executeHooks('deleteSupportUser', $parameters, $object, $action);
+
 		if (is_object($newdb)) {
 			$fordolibarr = 1;
 			if (preg_match('/glpi.*\.cloud/', $object->ref_customer)) {


### PR DESCRIPTION
This PR adds the call to the deleteSupportUser hook in the SellYourSaaS module to allow other modules to manage additional actions before deleting a support user. By using this hook, other modules can intervene to check and resolve constraints that may prevent the deletion of the user, such as data dependencies or entries associated with other tables.

If constraints prevent the deletion of the support user, the action will not be performed, and an error message will be displayed to the user:

This website or feature is currently temporarily not available or failed after a technical error. This may be due to a maintenance operation. Current status of operation (2025-03-25T11:02:08Z) are on next line...

This allows flexible and modular management of support users across Dolibarr, facilitating the integration of custom rules or processes while ensuring a clean deletion or a clear error message in case of issues.

see 
(https://github.com/DoliCloud/SellYourSaas/pull/416)