### PR TITLE
Create spam directory on master, not on deployment server

### DIFF
--- a/doc/Documentation SellYourSaas - Master and Deployment Servers - EN.asciidoc
+++ b/doc/Documentation SellYourSaas - Master and Deployment Servers - EN.asciidoc
@@ -712,7 +712,6 @@ ln -fs /mnt/diskhome/backup /mnt/diskbackup
 mkdir /home/jail; mkdir /mnt/diskhome/home;
 
 mkdir /mnt/diskbackup/archives-test; mkdir /mnt/diskbackup/archives-paid
-mkdir -p /home/admin/wwwroot/dolibarr_documents/sellyoursaas/spam;
 chown admin:root /mnt/diskbackup/backup /mnt/diskbackup/archives-test /mnt/diskbackup/archives-paid
 ln -fs /mnt/diskhome/home /home/jail/home
 ln -fs /mnt/diskbackup/backup /home/jail/backup 
@@ -3212,6 +3211,7 @@ Create the sample files that will be used for antispam internal features of Sell
 
 [source,bash]
 ---------------
+mkdir -p /home/admin/wwwroot/dolibarr_documents/sellyoursaas/spam;
 echo >> /home/admin/wwwroot/dolibarr_documents/sellyoursaas/spam/blacklistmail;
 echo >> /home/admin/wwwroot/dolibarr_documents/sellyoursaas/spam/blacklistip;
 echo >> /home/admin/wwwroot/dolibarr_documents/sellyoursaas/spam/blacklistfrom;

--- a/doc/Documentation SellYourSaas - Master and Deployment Servers - EN.asciidoc
+++ b/doc/Documentation SellYourSaas - Master and Deployment Servers - EN.asciidoc
@@ -705,13 +705,15 @@ mkdir /mnt/diskhome/backup; chown admin /mnt/diskhome/backup;
 ln -fs /mnt/diskhome/backup /mnt/diskbackup
 ---------------
 
-* Create the other directories on the deployment server:
+* Create the other directories on the *Deployment* servers:
 
 [source, bash]
 ---------------
 mkdir /home/jail; mkdir /mnt/diskhome/home;
 
 mkdir /mnt/diskbackup/archives-test; mkdir /mnt/diskbackup/archives-paid
+mkdir -p /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/spam;
+mkdir -p /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt;
 chown admin:root /mnt/diskbackup/backup /mnt/diskbackup/archives-test /mnt/diskbackup/archives-paid
 ln -fs /mnt/diskhome/home /home/jail/home
 ln -fs /mnt/diskbackup/backup /home/jail/backup 


### PR DESCRIPTION
`/home/admin/wwwroot/dolibarr_documents/sellyoursaas/spam` is per documentation created on the deployment server on a path that later becomes the NFS mount. On the master we are writing files in this directory, which at that point doesn't exist, since the instructions create it on the deployment server. This fixes it.