### PR TITLE
fix: [BUG] data too long for "source_url" field in "llx_mailing_cibles"

### DIFF
--- a/class/actions_sellyoursaas.class.php
+++ b/class/actions_sellyoursaas.class.php
@@ -99,6 +99,11 @@ class ActionsSellyoursaas
 
 			// Dashboard
 			if ($user->hasRight('sellyoursaas', 'read') && ! empty($tmparray['options_dolicloud'])) {
+				$pagessavinggetnomurlintoashortfield = array('advtargetemailing.php', 'targetemailing.php');
+				if (in_array((empty($_SERVER['PHP_SELF']) ? '' : basename($_SERVER['PHP_SELF'])), $pagessavinggetnomurlintoashortfield)) {
+					return 0;
+				}
+
 				$url = '';
 				if ($tmparray['options_dolicloud'] == 'yesv2') {
 					$urlmyaccount = getDolGlobalString('SELLYOURSAAS_ACCOUNT_URL');


### PR DESCRIPTION
Fixes #472

## Root cause

getNomUrl hook injects a long auto-login dashboard link that overflows llx_mailing_cibles.source_url (varchar 255)

## Changes

- In the SellYourSaas getNomUrl hook for thirdparties, skip the enrichment (auto-login dashboard link and spammer picto) when the link is produced on Dolibarr emailing target pages (advtargetemailing.php / targetemailing.php), where the returned string is stored into the varchar(255) source_url column by mailing_advthirdparties::add_to_target_spec().