### PR TITLE
fix: Error "Too many pending requests" when creating SaaS instance

### DIFF
--- a/myaccount/register_instance.php
+++ b/myaccount/register_instance.php
@@ -889,9 +889,13 @@ if ($reusecontractid) {
 	}
 
 	// Check if some deployment are already in process and ask to wait
-	$MAXDEPLOYMENTPARALLEL = getDolGlobalInt('SELLYOURSAAS_MAXDEPLOYMENTPARALLEL', 2);
+	$MAXDEPLOYMENTPARALLEL = getDolGlobalInt('SELLYOURSAAS_MAXDEPLOYMENTPARALLEL', 4);
 	if ($MAXDEPLOYMENTPARALLEL <= 0) {	// Protection to avoid problems
 		$MAXDEPLOYMENTPARALLEL = 1;
+	}
+	$MAXDELAYFORDEPLOYMENTINPROGRESS = getDolGlobalInt('SELLYOURSAAS_MAXDELAYFORDEPLOYMENTINPROGRESS', 3600);
+	if ($MAXDELAYFORDEPLOYMENTINPROGRESS <= 0) {
+		$MAXDELAYFORDEPLOYMENTINPROGRESS = 3600;
 	}
 
 	$tmp=explode('.', $sldAndSubdomain.$tldid, 2);
@@ -904,7 +908,7 @@ if ($reusecontractid) {
 	$select = 'SELECT COUNT(*) as nb FROM '.MAIN_DB_PREFIX."contrat_extrafields";
 	$select .= " WHERE deployment_host = '".$db->escape($serverdeployement)."'";
 	$select .= " AND deployment_status IN ('processing')";
-	$select .= " AND deployment_date_start >= DATE_SUB('".$db->idate(dol_now())."', INTERVAL 1 DAY)";	// We ignore deployment started more than 24h ago: They are supposed to be finished even if not correctly flagged as 'done'.
+	$select .= " AND deployment_date_start >= '".$db->idate(dol_now() - $MAXDELAYFORDEPLOYMENTINPROGRESS)."'";	// A deployment older than this delay is no more in progress, even if not correctly flagged as 'done'.
 	$resselect = $db->query($select);
 	if ($resselect) {
 		$objselect = $db->fetch_object($resselect);


### PR DESCRIPTION
Fixes #418

## Root cause

Stale 'processing' deployments block new instance creation for 24h

## Changes

- The counter of deployments 'in progress' now only considers deployments started within a bounded delay (new hidden option SELLYOURSAAS_MAXDELAYFORDEPLOYMENTINPROGRESS, default 3600s, far above the 300s deployall timeout and the 2 minutes after which the dashboard already offers a 'Restart') instead of the previous 24h window, so a deployment left flagged 'processing' can no longer lock instance creation for a day. The default of SELLYOURSAAS_MAXDEPLOYMENTPARALLEL was aligned with the value documented and pre-filled by admin/setup_register_security.php (4 instead of 2).