### PR TITLE
Fix restrict domains

### DIFF
--- a/myaccount/register.php
+++ b/myaccount/register.php
@@ -933,7 +933,7 @@ if ($reshook == 0) {
 							// If $tmppackage is defined, check if there is a restriction on some domains for this package (if not, $tmppackage->restrict_domains is empty and no restriction is done here)
 							if (! empty($tmppackage->restrict_domains)) {
 								$restrictfound = false;
-								$tmparray=explode(',', $tmppackage->restrict_domains);
+								$tmparray=array_map('trim', explode(',', $tmppackage->restrict_domains));
 								foreach ($tmparray as $tmprestrictdomain) {
 									$newdomain = getDomainFromURL($newval, 1);
 									if ($newdomain == $tmprestrictdomain) {

--- a/myaccount/tpl/instances.tpl.php
+++ b/myaccount/tpl/instances.tpl.php
@@ -2084,11 +2084,9 @@ if ($MAXINSTANCESPERACCOUNT && count($listofcontractidopen) < $MAXINSTANCESPERAC
 		foreach ($arrayofplansfull as $key => $tmpplan) {
 			if (!empty($tmpplan['restrict_domains'])) {
 				$restrict_domains = explode(",", $tmpplan['restrict_domains']);
+				$restrict_domains = array_map('trim', $restrict_domains);
 				print "/* Code if we select pid = ".$key." so plan = ".$tmpplan['label']." with restrict_domains = ".$tmpplan['restrict_domains']." */\n";
-				foreach ($restrict_domains as $domain) {
-					print " if (pid == ".$key.") { disable_tld_if_not('".trim($domain)."'); }\n";
-					break;	// We keep only the first domain in list as the domain to keep possible for deployment
-				}
+				print " if (pid == ".$key.") { disable_tld_if_not('".implode(',', $restrict_domains)."'); }\n";
 			} else {
 				print '	/* No restriction for pid = '.$key.', currentdomain is '.$domainname." */\n";
 			}
@@ -2170,8 +2168,14 @@ if ($MAXINSTANCESPERACCOUNT && count($listofcontractidopen) < $MAXINSTANCESPERAC
 
 					function disable_tld_if_not(s) {
 						console.log("Disable combo choice except if s="+s);
+						var allowedDomains = s.split(",");
 						$("#tldid > option").each(function() {
-							if (this.value && !this.value.endsWith(s)) {
+							if (!this.value) {
+								return;
+							}
+							var optionValue = this.value;
+							var matched = allowedDomains.some(function(d) { return optionValue.endsWith(d); });
+							if (!matched) {
 								console.log("We disable the option "+this.value);
 								$(this).attr("disabled", "disabled");
 								$(this).removeAttr("selected");

--- a/myaccount/tpl/mycustomerinstances.tpl.php
+++ b/myaccount/tpl/mycustomerinstances.tpl.php
@@ -1021,7 +1021,9 @@ if (getDolGlobalInt('SELLYOURSAAS_DISABLE_NEW_INSTANCES') && !in_array(getUserRe
 				$restrict_domains = explode(",", $tmpplan['restrict_domains']);
 				foreach ($restrict_domains as $domain) {
 					print " if (pid == ".$key.") { disable_combo_if_not('".$domain."'); }\n";
-					break;
+					if ($domain == $domainname) {
+						break;	// We keep only the first domain in list as the domain to keep possible for deployment
+					}
 				}
 			} else {
 				print '	/* No restriction for pid = '.$key.', currentdomain is '.$domainname.' */'."\n";


### PR DESCRIPTION
@eldy @Hystepik 

Summary

  Packages/plans can restrict which domains an instance may be deployed on via the restrict_domains field (comma-separated, e.g. example1.com, example2.net).
  In two places, the code that builds the client-side domain-filtering JS only ever considered the first domain in that list, silently disabling every other
  allowed domain in the tldid selector.

  Changes

  - myaccount/tpl/instances.tpl.php: the loop generating disable_tld_if_not() calls always breaked after the first domain, so only that one domain was ever
    passed to the JS filter. Now all allowed domains are passed in a single call, and an option is disabled only if it matches none of them.
  - myaccount/register.php: explode(',', $restrict_domains) didn't trim whitespace, so a value like "example1.com, example2.net" (space after the comma)
    failed the exact-match comparison for every domain but the first. Added trim().
  - myaccount/tpl/mycustomerinstances.tpl.php: same underlying "always break after first domain" pattern, fixed by stopping only once the current domain is
    found in the list (this keeps the intended reseller behavior of locking to the domain the reseller portal is currently on).

  Reproduction

  Set a package's "Visible on certain domains only" to two domains (e.g. example1.com, example2.net), then go to the customer instance page and try to add a
  new instance: the second domain's options in the tldid dropdown were greyed out even though they should have been selectable.
  
  Testing
  
  Verified via php -l on all changed files and by tracing the exact browser console log output (Disable combo choice except if s=example1.com) that confirmed
  only the first domain was ever reaching the JS filter. Not yet verified against a live deployment.