### PR TITLE
FIX uninstalling one option from myaccount undeploys every installed option

### DIFF
--- a/myaccount/index.php
+++ b/myaccount/index.php
@@ -2402,10 +2402,14 @@ if ($action == 'updateurl') {	// update URL from the tab "Domain"
 		setEventMessages($tmpcontract->error, null, 'errors');
 		$error++;
 	}
+	$tmplineforremoteaction = null;
 	if (!$error) {
 		foreach ($tmpcontract->lines as $key => $line) {
 			// Remove service line(s) from contract
 			if ($line->fk_product == $productid) {
+				if (empty($tmplineforremoteaction)) {
+					$tmplineforremoteaction = clone $line;	// Keep a copy of the line to target only this product's option for the remote undeploy action below (passing the whole contract would undeploy every installed option)
+				}
 				$res = $tmpcontract->deleteLine($line->id, $user);
 				if ($res <= 0) {
 					setEventMessages($tmpcontract->error, null, 'errors');
@@ -2478,7 +2482,7 @@ if ($action == 'updateurl') {	// update URL from the tab "Domain"
 		$object->username_web = $username_web;
 		$object->password_web = $password_web;
 
-		$result = $sellyoursaasutils->sellyoursaasRemoteAction("undeployoption", $object);
+		$result = $sellyoursaasutils->sellyoursaasRemoteAction("undeployoption", $tmplineforremoteaction);
 		if ($result <= 0) {
 			$error++;
 			setEventMessages($sellyoursaasutils->error, $sellyoursaasutils->errors, 'errors');
@@ -2584,6 +2588,13 @@ if ($action == 'updateurl') {	// update URL from the tab "Domain"
 
 	// Call to remoteaction to deploy option
 	if (!$error) {
+		$tmplineforremoteaction = null;
+		foreach ($tmpcontract->lines as $key => $line) {
+			if ($line->id == $idlinecontract) {
+				$tmplineforremoteaction = $line;	// Target only this newly installed option's line for the remote deploy action below (passing the whole contract would redeploy every installed option)
+				break;
+			}
+		}
 		$object = $tmpcontract;
 		$type_db = $conf->db->type;
 		$hostname_db  = $object->array_options['options_hostname_db'];
@@ -2614,7 +2625,7 @@ if ($action == 'updateurl') {	// update URL from the tab "Domain"
 		$object->password_web = $password_web;
 
 		//$object->context["options_websitename"] = $website->ref;
-		$result = $sellyoursaasutils->sellyoursaasRemoteAction("deployoption", $object);	// Why "rename" and not "deploycustomurl" ?
+		$result = $sellyoursaasutils->sellyoursaasRemoteAction("deployoption", $tmplineforremoteaction);
 		if ($result <= 0) {
 			$error++;
 			setEventMessages($sellyoursaasutils->error, $sellyoursaasutils->errors, 'errors');


### PR DESCRIPTION
## Problem

On the customer myaccount dashboard, installing/uninstalling one option on an instance that has several options installed affects *all* installed options, not just the targeted one.

## Cause

`SellYourSaasUtils::sellyoursaasRemoteAction()` treats a `Contrat` object specially: it loops over *all* of the contract's lines and re-qualifies every `option` product line that has a package for `deployoption`/`undeployoption`. `myaccount/index.php`'s `install`/`uninstall` actions pass the whole `Contrat` (all lines) instead of the single targeted line, so the remote deploy/undeploy call ends up looping over every installed option.

## Fix

Pass the specific `ContratLigne` (the newly added/removed line) to `sellyoursaasRemoteAction()` instead of the whole contract, so only the targeted option is qualified.