### PR TITLE
FIX Redeploy from contract card always reset admin password to an empty hash

### DIFF
--- a/class/actions_sellyoursaas.class.php
+++ b/class/actions_sellyoursaas.class.php
@@ -23,6 +23,7 @@
  */
 require_once DOL_DOCUMENT_ROOT."/core/class/commonobject.class.php";
 require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture-rec.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/security2.lib.php';
 dol_include_once('sellyoursaas/lib/sellyoursaas.lib.php');
 dol_include_once('sellyoursaas/class/deploymentserver.class.php');
 
@@ -432,14 +433,35 @@ class ActionsSellyoursaas
 				}
 
 				if (! $error) {
+					// deployall recreates the admin user from scratch, so it always needs a real password to set, not
+					// just one to display. options_deployment_init_adminpass is emptied once the very first deploy is
+					// marked done (see register_instance.php, "Clear password, we don't need it anymore"), unless
+					// SELLYOURSAAS_KEEP_INIT_ADMINPASS is set - so on every later Redeploy from this card, this field
+					// is expected to already be empty when that constant is off. Generate a fresh password here
+					// instead of silently sending an empty string as the new admin password. If the constant is on,
+					// the field finding itself empty anyway is not the expected case, so leave it alone rather than
+					// paper over it - that configuration means the real password should always be known/kept.
+					$adminpassforredeploy = $object->array_options['options_deployment_init_adminpass'];
+					$generatedadminpassforredeploy = false;
+					if (empty($adminpassforredeploy) && !getDolGlobalString('SELLYOURSAAS_KEEP_INIT_ADMINPASS')) {
+						$adminpassforredeploy = substr(getRandomPassword(true, array('I')), 0, 9);
+						$generatedadminpassforredeploy = true;
+					}
+
 					dol_include_once('sellyoursaas/class/sellyoursaasutils.class.php');
 					$sellyoursaasutils = new SellYourSaasUtils($db);
-					$result = $sellyoursaasutils->sellyoursaasRemoteAction('deployall', $object, 'admin', $object->thirdparty->email, $object->array_options['options_deployment_init_adminpass'], '0', 'Deploy from contract card', 300);
+					$result = $sellyoursaasutils->sellyoursaasRemoteAction('deployall', $object, 'admin', $object->thirdparty->email, $adminpassforredeploy, '0', 'Deploy from contract card', 300);
 					if ($result <= 0) {
 						$error++;
 						$this->error=$sellyoursaasutils->error;
 						$this->errors=$sellyoursaasutils->errors;
 						setEventMessages($this->error, $this->errors, 'errors');
+					} elseif ($generatedadminpassforredeploy) {
+						// Store it back so it is not lost, and show it once: this is the only place it is recorded now,
+						// there is no email sent for it (the customer chooses their own password on first registration).
+						$object->array_options['options_deployment_init_adminpass'] = $adminpassforredeploy;
+						$object->insertExtraFields();
+						setEventMessages($langs->trans('SellYourSaasNewAdminPasswordAfterRedeploy', $adminpassforredeploy), null, 'warnings');
 					}
 				}
 

--- a/langs/en_US/sellyoursaas.lang
+++ b/langs/en_US/sellyoursaas.lang
@@ -490,6 +490,7 @@ CreateMyAccount=Create my account
 YouDontHaveCustomersYet=You don't have customers yet. Promote the link provided in top of page to find new prospects or customers...
 ManualCollection=Manual invoicing
 NoEmailSentToInformCustomer=No email sent to inform user.
+SellYourSaasNewAdminPasswordAfterRedeploy=The admin password stored for this contract was empty (cleared after the first deploy), so a new one was generated for this redeploy and is not sent by email: %s
 EvilUser=Unfair user or spammer
 DisableEmailToCustomer=Do not send email to customer
 CommissionsOnOldSystem=Commissions on old system

--- a/langs/fr_FR/sellyoursaas.lang
+++ b/langs/fr_FR/sellyoursaas.lang
@@ -489,6 +489,7 @@ CreateMyAccount=Créer mon compte
 YouDontHaveCustomersYet=Vous n'avez pas encore de clients. Promouvez le lien fourni en haut de cette page pour trouver des prospects ou clients...
 ManualCollection=Facturation manuelle
 NoEmailSentToInformCustomer=Aucun email a été envoyé pour informer l'utilisateur
+SellYourSaasNewAdminPasswordAfterRedeploy=Le mot de passe admin stocké pour ce contrat était vide (effacé après le premier déploiement), un nouveau a été généré pour ce redéploiement et n'est pas envoyé par email : %s
 EvilUser=Utilisateur déloyal ou spammeur
 DisableEmailToCustomer=Ne pas envoyer d'e-mail au client
 CommissionsOnOldSystem=Commissions sur l'ancienne plateforme


### PR DESCRIPTION
deployall recreates the admin user from scratch using options_deployment_init_adminpass as the new password, but that field is emptied right after the very first deploy is marked done (see register_instance.php, unless SELLYOURSAAS_KEEP_INIT_ADMINPASS is set) - so every subsequent Redeploy from the contract card was silently sending an empty string as the admin password, leaving the instance's admin account effectively unusable until a manual password reset.

Generate a fresh password when the stored one is empty (and the KEEP constant is off), use it for the deploy, store it back, and show it once to the admin via an event message - there is no email sent for it, the customer sets their own password at first registration.

Tested live on a real redeploy: correctly generates and displays a new working password.