### PR TITLE
FIX favicon href doubled when MAIN_FAVICON_URL is an absolute URL

### DIFF
--- a/myaccount/index.php
+++ b/myaccount/index.php
@@ -2740,7 +2740,11 @@ $arrayofjs=array(
 
 $head = '';
 if ($favicon) {
-	$head.='<link rel="icon" href="img/'.$favicon.'">'."\n";
+	$hreffavicon = 'img/'.$favicon;
+	if (preg_match('/^http/i', $favicon)) {
+		$hreffavicon = $favicon;
+	}
+	$head.='<link rel="icon" href="'.$hreffavicon.'">'."\n";
 }
 $head.='<!-- Bootstrap core CSS -->
 <link href="dist/css/bootstrap.css" type="text/css" rel="stylesheet">

--- a/myaccount/register_instance.php
+++ b/myaccount/register_instance.php
@@ -1795,7 +1795,11 @@ if (getDolGlobalString('MAIN_FAVICON_URL')) {
 
 $head = '';
 if ($favicon) {
-	$head.='<link rel="icon" href="img/'.$favicon.'">'."\n";
+	$hreffavicon = 'img/'.$favicon;
+	if (preg_match('/^http/i', $favicon)) {
+		$hreffavicon = $favicon;
+	}
+	$head.='<link rel="icon" href="'.$hreffavicon.'">'."\n";
 }
 $head .= '<!-- Bootstrap core CSS -->';
 $head .= '<link href="dist/css/bootstrap.css" type="text/css" rel="stylesheet">';


### PR DESCRIPTION
myaccount/index.php and myaccount/register_instance.php built the favicon href by
blindly prefixing `img/`, unlike the other myaccount templates (loginmyaccount.tpl.php,
passwordforgotten.tpl.php, mainmyaccount.inc.php) which already guard against
`MAIN_FAVICON_URL` being an absolute http(s) URL.

When `MAIN_FAVICON_URL` is set to an absolute URL, this produced a malformed
`href="img/https://.../favicon.ico"`, 404ing in the browser console.

Fix: same guard as the other templates - use the absolute URL as-is when it
already starts with `http`.