### PR TITLE
Fix remote agent signature check and custom URL SSL/edge-case bugs

### DIFF
--- a/core/lib/sellyoursaas.lib.php
+++ b/core/lib/sellyoursaas.lib.php
@@ -418,10 +418,20 @@ function getListOfLinks($object, $lastloginadmin, $lastpassadmin)
 
 	// Generate certificate on customer domain name
 	if (!empty($object->array_options['options_custom_url'])) {
-		$generatecertif='certbot certonly --webroot -w '.$homestring.'/'.$object->database_db.'/htdocs -d '.$object->array_options['options_custom_url']."\n";
-		$generatecertif.='ln -fs /etc/letsencrypt/live/'.$object->array_options['options_custom_url'].'/privkey.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/'.$object->hostname_db.'-'.$object->array_options['options_custom_url'].'.key'."\n";
-		$generatecertif.='ln -fs /etc/letsencrypt/live/'.$object->array_options['options_custom_url'].'/cert.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/'.$object->hostname_db.'-'.$object->array_options['options_custom_url'].'.crt'."\n";
-		$generatecertif.='ln -fs /etc/letsencrypt/live/'.$object->array_options['options_custom_url'].'/fullchain.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/'.$object->hostname_db.'-'.$object->array_options['options_custom_url'].'-intermediate.crt'."\n";
+		// newdoldataroot is only known on the target deployment server (its own /etc/sellyoursaas.conf),
+		// never on the master rendering this suggested command - so resolve it in the pasted shell itself,
+		// with the same fallback as every action_*.sh script, instead of hardcoding the old default path.
+		// Also use ref_customer (the instance's own fqn, e.g. "instancename.withX.domain.com") and the
+		// literal "-custom" suffix for the cache filename, matching exactly what action_suspend_unsuspend.sh/
+		// action_deploy_undeploy.sh actually name these files ($fqn-custom.*) - hostname_db is unrelated
+		// (it defaults to the instance's database server hostname/IP at provisioning time, only ever
+		// happening to match ref_customer after a rename), and using the custom domain name itself as the
+		// filename suffix instead of "-custom" would never match what the real vhost actually references.
+		$generatecertif ='newdoldataroot=`grep "^newdoldataroot=" /etc/sellyoursaas.conf | cut -d "=" -f 2`'."\n";
+		$generatecertif.='certbot certonly --webroot -w '.$homestring.'/'.$object->database_db.'/htdocs -d '.$object->array_options['options_custom_url']."\n";
+		$generatecertif.='ln -fs /etc/letsencrypt/live/'.$object->array_options['options_custom_url'].'/privkey.pem ${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt/'.$object->ref_customer.'-custom.key'."\n";
+		$generatecertif.='ln -fs /etc/letsencrypt/live/'.$object->array_options['options_custom_url'].'/cert.pem ${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt/'.$object->ref_customer.'-custom.crt'."\n";
+		$generatecertif.='ln -fs /etc/letsencrypt/live/'.$object->array_options['options_custom_url'].'/fullchain.pem ${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt/'.$object->ref_customer.'-custom-intermediate.crt'."\n";
 	} else {
 		$generatecertif='No custom domain for this instance';
 	}

--- a/scripts/action_customurl_instance.sh
+++ b/scripts/action_customurl_instance.sh
@@ -300,11 +300,11 @@ if [[ "$mode" == "deploycustomurl" ]]; then
 		sleep 3
 	fi
 
-	export customcrtfolder="/home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt"
+	export customcrtfolder="${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt"
 
 	if [[ ! -d $customcrtfolder ]]; then
-		echo "Create cert directory with mkdir $customcrtfolder; chown admin:admin $customcrtfolder;"
-		mkdir $customcrtfolder; chown admin:admin $customcrtfolder;
+		echo "Create cert directory with mkdir -p $customcrtfolder; chown admin:admin $customcrtfolder;"
+		mkdir -p $customcrtfolder; chown admin:admin $customcrtfolder;
 	fi
 
 	echo `date +'%Y-%m-%d %H:%M:%S'`" Generation of cert file for custom url"
@@ -325,15 +325,15 @@ if [[ "$mode" == "deploycustomurl" ]]; then
 
 	echo `date +'%Y-%m-%d %H:%M:%S'`" Link of generated cert file for custom url"
 	echo "Link certificate for virtualhost with
-		ln -fs /etc/letsencrypt/live/www.$customurl/privkey.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$instancename.$domainname-$customurl.key
-		ln -fs /etc/letsencrypt/live/www.$customurl/cert.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$instancename.$domainname-$customurl.crt
-		ln -fs /etc/letsencrypt/live/www.$customurl/fullchain.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$instancename.$domainname-$customurl-intermediate.crt
+		ln -fs /etc/letsencrypt/live/www.$customurl/privkey.pem $customcrtfolder/$instancename.$domainname-$customurl.key
+		ln -fs /etc/letsencrypt/live/www.$customurl/cert.pem $customcrtfolder/$instancename.$domainname-$customurl.crt
+		ln -fs /etc/letsencrypt/live/www.$customurl/fullchain.pem $customcrtfolder/$instancename.$domainname-$customurl-intermediate.crt
 	"
-	ln -fs /etc/letsencrypt/live/www.$customurl/privkey.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$instancename.$domainname-$customurl.key
+	ln -fs /etc/letsencrypt/live/www.$customurl/privkey.pem $customcrtfolder/$instancename.$domainname-$customurl.key
 	export certkeyko=$?
-	ln -fs /etc/letsencrypt/live/www.$customurl/cert.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$instancename.$domainname-$customurl.crt
+	ln -fs /etc/letsencrypt/live/www.$customurl/cert.pem $customcrtfolder/$instancename.$domainname-$customurl.crt
 	export certcrtko=$?
-	ln -fs /etc/letsencrypt/live/www.$customurl/fullchain.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$instancename.$domainname-$customurl-intermediate.crt
+	ln -fs /etc/letsencrypt/live/www.$customurl/fullchain.pem $customcrtfolder/$instancename.$domainname-$customurl-intermediate.crt
 	export certinterko=$?
 
 	if [[ "x$certkeyko" != "x0" ]] || [[ "x$certcrtko" != "x0" ]] || [[ "x$certinterko" != "x0" ]]; then

--- a/scripts/action_deploy_undeploy.sh
+++ b/scripts/action_deploy_undeploy.sh
@@ -1201,12 +1201,16 @@ if [[ "$mode" == "deploy" || "$mode" == "deployall" ]]; then
 	# Remove and recreate customurl
 	rm -f /etc/apache2/sellyoursaas-available/$fqn.custom.conf
 	rm -f /etc/apache2/sellyoursaas-online/$fqn.custom.conf
+	# Also remove any certificate files left from a previous custom domain for this instance
+	# (we don't know the old customurl value here, only $fqn, so match on that prefix instead)
+	rm -f ${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt/$fqn-*.crt
+	rm -f ${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt/$fqn-*.key
 	if [[ "x$customurl" != "x" ]]; then
 
 		echo `date +'%Y-%m-%d %H:%M:%S'`" ***** Create apache conf $apacheconf from $vhostfile"
 
 		export pathforcertifmaster="/home/admin/wwwroot/dolibarr_documents/sellyoursaas/crt"
-		export pathforcertiflocal="/home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt"
+		export pathforcertiflocal="${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt"
 
 		# Delete old custom conf file
 		export apacheconf="/etc/apache2/sellyoursaas-available/$fqn.custom.conf"
@@ -1279,18 +1283,24 @@ if [[ "$mode" == "deploy" || "$mode" == "deployall" ]]; then
 			# No $CERTIFFORCUSTOMDOMAIN forced (no cert file was created initially), so we will generate one
 			export domainnameorcustomurl=`echo $customurl | cut -d "." -f 1`
 
-			# TODO We must create it using letsencrypt if not yet created. NOTE: This is done in action "rename" (suspen_unsuspend.sh), not sure we must also do it  on deploy.
-			#if [[ ! -e /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$fqn.crt ]]; then
-					# Generate the letsencrypt certificate
+			# If no cached copy exists yet for this instance's custom domain, but a real
+			# Let's Encrypt certificate for the domain itself already exists (e.g. left
+			# over from a previous custom-URL setup that was removed then recreated),
+			# link it into the cache now instead of silently falling back to the
+			# wildcard below - the wildcard does not cover an external custom domain.
+			if [[ ! -e $pathforcertiflocal/$fqn-custom.crt ]]; then
+				if [[ -e /etc/letsencrypt/live/$customurl/cert.pem ]]; then
+					ln -fs /etc/letsencrypt/live/$customurl/cert.pem $pathforcertiflocal/$fqn-custom.crt
+					ln -fs /etc/letsencrypt/live/$customurl/privkey.pem $pathforcertiflocal/$fqn-custom.key
+					ln -fs /etc/letsencrypt/live/$customurl/fullchain.pem $pathforcertiflocal/$fqn-custom-intermediate.crt
+				elif [[ -e /etc/letsencrypt/live/www.$customurl/cert.pem ]]; then
+					ln -fs /etc/letsencrypt/live/www.$customurl/cert.pem $pathforcertiflocal/$fqn-custom.crt
+					ln -fs /etc/letsencrypt/live/www.$customurl/privkey.pem $pathforcertiflocal/$fqn-custom.key
+					ln -fs /etc/letsencrypt/live/www.$customurl/fullchain.pem $pathforcertiflocal/$fqn-custom-intermediate.crt
+				fi
+			fi
 
-					# certbot certonly -n -v --webroot -w $instancedir -d $customurl
-					# create links
-
-					# If links does not exists, we disable SSL
-					#SSLON="Off"
-			#fi
-
-			if [[ ! -e /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$fqn-custom.crt ]]; then
+			if [[ ! -e $pathforcertiflocal/$fqn-custom.crt ]]; then
 				# If custom cert not found, we fallback on the wildcard one for server (it will generate a warning, but it will works and not hangs !)
 				export webCustomSSLCertificateCRT="/etc/apache2/$webSSLCertificateCRT"
 				export webCustomSSLCertificateKEY="/etc/apache2/$webSSLCertificateKEY"
@@ -1298,9 +1308,9 @@ if [[ "$mode" == "deploy" || "$mode" == "deployall" ]]; then
 				export CERTIFFORCUSTOMDOMAIN="with.sellyoursaas.com"
 			else
 				# We will use the custom cert file
-				export webCustomSSLCertificateCRT=/home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$fqn-custom.crt
-				export webCustomSSLCertificateKEY=/home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$fqn-custom.key
-				export webCustomSSLCertificateIntermediate=/home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$fqn-custom-intermediate.crt
+				export webCustomSSLCertificateCRT=$pathforcertiflocal/$fqn-custom.crt
+				export webCustomSSLCertificateKEY=$pathforcertiflocal/$fqn-custom.key
+				export webCustomSSLCertificateIntermediate=$pathforcertiflocal/$fqn-custom-intermediate.crt
 				export CERTIFFORCUSTOMDOMAIN="$fqn-custom"
 			fi
 			echo "We will use the certificate file webCustomSSLCertificateCRT=$webCustomSSLCertificateCRT (CERTIFFORCUSTOMDOMAIN=$CERTIFFORCUSTOMDOMAIN)"
@@ -1525,6 +1535,10 @@ if [[ "$mode" == "undeploy" || "$mode" == "undeployall" ]]; then
 		echo Disable conf with a2dissite $fqn.custom.conf
 		#a2dissite $fqn.conf
 		rm /etc/apache2/sellyoursaas-online/$fqn.custom.conf
+
+		echo Remove any custom domain certificate files left for this instance
+		rm -f ${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt/$fqn-*.crt
+		rm -f ${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt/$fqn-*.key
 
 		echo Disable conf with a2dissite $fqn.website*.conf
 		#a2dissite $fqn.conf

--- a/scripts/action_suspend_unsuspend.sh
+++ b/scripts/action_suspend_unsuspend.sh
@@ -247,10 +247,10 @@ testorconfirm="confirm"
 
 
 # Create target directory /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt if it does not exists
-export pathforcertiflocal="/home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt"
+export pathforcertiflocal="${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt"
 if [[ ! -d $pathforcertiflocal ]]; then
-	echo "Create cert directory with mkdir $pathforcertiflocal; chown admin:admin $pathforcertiflocal;"
-	mkdir $pathforcertiflocal; chown admin:admin $pathforcertiflocal;
+	echo "Create cert directory with mkdir -p $pathforcertiflocal; chown admin:admin $pathforcertiflocal;"
+	mkdir -p $pathforcertiflocal; chown admin:admin $pathforcertiflocal;
 fi
 
 
@@ -341,11 +341,15 @@ if [[ "$mode" == "rename" ]]; then
 	# Remove and recreate customurl
 	rm -f /etc/apache2/sellyoursaas-available/$fqn.custom.conf
 	rm -f /etc/apache2/sellyoursaas-online/$fqn.custom.conf
+	# Also remove any certificate files left from a previous custom domain for this instance
+	# (we don't know the old customurl value here, only $fqn, so match on that prefix instead)
+	rm -f ${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt/$fqn-*.crt
+	rm -f ${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt/$fqn-*.key
 	if [[ "x$customurl" != "x" ]]; then
 		echo `date +'%Y-%m-%d %H:%M:%S'`" ***** For instance in $targetdir/$osusername/$dbname and mode=rename, we will create a new custom virtual name $fqn.custom"
 
 		export pathforcertifmaster="/home/admin/wwwroot/dolibarr_documents/sellyoursaas/crt"
-		export pathforcertiflocal="/home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt"
+		export pathforcertiflocal="${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt"
 	
 		echo `date +'%Y-%m-%d %H:%M:%S'`" Check that SSL files for $fqn.custom exists and create them if not (CERTIFFORCUSTOMDOMAIN=$CERTIFFORCUSTOMDOMAIN)"
 		if [[ "x$CERTIFFORCUSTOMDOMAIN" != "x" ]]; then
@@ -392,7 +396,7 @@ if [[ "$mode" == "rename" ]]; then
 			export domainnameorcustomurl=`echo $customurl | cut -d "." -f 1`
 			
 			# We must create the custom CRT file using letsencrypt if not yet created
-			if [[ ! -e /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$fqn-custom.crt ]]; then
+			if [[ ! -e ${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt/$fqn-custom.crt ]]; then
 				# When we rename, it may be because we change abc.with... into def.with..., or
 				# because we added a custom url.
 
@@ -436,9 +440,9 @@ if [[ "$mode" == "rename" ]]; then
 				echo "cat $vhostfile | sed -e 's/__webAppDomain__/$customurl/g' | \
 						  sed -e 's/__webAppAliases__/$customurl/g' | \
 						  sed -e 's/__webAppLogName__/$instancename/g' | \
-		                  sed -e 's;/etc/apache2/__webSSLCertificateCRT__;$pathforcertiflocal/$webCustomSSLCertificateCRT;g' | \
-		                  sed -e 's;/etc/apache2/__webSSLCertificateKEY__;$pathforcertiflocal/$webCustomSSLCertificateKEY;g' | \
-		                  sed -e 's;/etc/apache2/__webSSLCertificateIntermediate__;$pathforcertiflocal/$webCustomSSLCertificateIntermediate;g' | \
+		                  sed -e 's;\(/etc/apache2/\)\{0,1\}__webSSLCertificateCRT__;$pathforcertiflocal/$webCustomSSLCertificateCRT;g' | \
+		                  sed -e 's;\(/etc/apache2/\)\{0,1\}__webSSLCertificateKEY__;$pathforcertiflocal/$webCustomSSLCertificateKEY;g' | \
+		                  sed -e 's;\(/etc/apache2/\)\{0,1\}__webSSLCertificateIntermediate__;$pathforcertiflocal/$webCustomSSLCertificateIntermediate;g' | \
 						  sed -e 's/__webAdminEmail__/$EMAILFROM/g' | \
 						  sed -e 's/__osUsername__/$osusername/g' | \
 						  sed -e 's/__osGroupname__/$osusername/g' | \
@@ -458,9 +462,9 @@ if [[ "$mode" == "rename" ]]; then
 				cat $vhostfile | sed -e "s/__webAppDomain__/$customurl/g" | \
 						  sed -e "s/__webAppAliases__/$customurl/g" | \
 						  sed -e "s/__webAppLogName__/$instancename/g" | \
-		                  sed -e "s;/etc/apache2/__webSSLCertificateCRT__;$pathforcertiflocal/$webCustomSSLCertificateCRT;g" | \
-		                  sed -e "s;/etc/apache2/__webSSLCertificateKEY__;$pathforcertiflocal/$webCustomSSLCertificateKEY;g" | \
-		                  sed -e "s;/etc/apache2/__webSSLCertificateIntermediate__;$pathforcertiflocal/$webCustomSSLCertificateIntermediate;g" | \
+		                  sed -e "s;\(/etc/apache2/\)\{0,1\}__webSSLCertificateCRT__;$pathforcertiflocal/$webCustomSSLCertificateCRT;g" | \
+		                  sed -e "s;\(/etc/apache2/\)\{0,1\}__webSSLCertificateKEY__;$pathforcertiflocal/$webCustomSSLCertificateKEY;g" | \
+		                  sed -e "s;\(/etc/apache2/\)\{0,1\}__webSSLCertificateIntermediate__;$pathforcertiflocal/$webCustomSSLCertificateIntermediate;g" | \
 						  sed -e "s/__webAdminEmail__/$EMAILFROM/g" | \
 						  sed -e "s/__osUsername__/$osusername/g" | \
 						  sed -e "s/__osGroupname__/$osusername/g" | \
@@ -530,20 +534,21 @@ if [[ "$mode" == "rename" ]]; then
 					ls -l "/etc/letsencrypt/live/$customurl/cert.pem"
 
 					echo `date +'%Y-%m-%d %H:%M:%S'`" Link of generated cert file for custom url"
+					mkdir -p ${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt
 					echo "Link certificate for the virtualhost of the custom url with
-						ln -fs /etc/letsencrypt/live/$customurl/privkey.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$fqn-custom.key
-						ln -fs /etc/letsencrypt/live/$customurl/cert.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$fqn-custom.crt
-						ln -fs /etc/letsencrypt/live/$customurl/fullchain.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$fqn-custom-intermediate.crt
+						ln -fs /etc/letsencrypt/live/$customurl/privkey.pem ${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt/$fqn-custom.key
+						ln -fs /etc/letsencrypt/live/$customurl/cert.pem ${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt/$fqn-custom.crt
+						ln -fs /etc/letsencrypt/live/$customurl/fullchain.pem ${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt/$fqn-custom-intermediate.crt
 					"
-					ln -fs /etc/letsencrypt/live/$customurl/privkey.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$fqn-custom.key
-					ln -fs /etc/letsencrypt/live/$customurl/cert.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$fqn-custom.crt
-					ln -fs /etc/letsencrypt/live/$customurl/fullchain.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$fqn-custom-intermediate.crt
+					ln -fs /etc/letsencrypt/live/$customurl/privkey.pem ${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt/$fqn-custom.key
+					ln -fs /etc/letsencrypt/live/$customurl/cert.pem ${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt/$fqn-custom.crt
+					ln -fs /etc/letsencrypt/live/$customurl/fullchain.pem ${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt/$fqn-custom-intermediate.crt
 				else
 					echo `date +'%Y-%m-%d %H:%M:%S'`" File /etc/letsencrypt/live/$customurl/cert.pem generated by certbot was not found (should not happen if certbot was not launched in dry-run)"
 				fi
 			fi
 			
-			if [[ ! -e "/home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$fqn-custom.crt" ]]; then
+			if [[ ! -e "${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt/$fqn-custom.crt" ]]; then
 				# If custom cert not found, we fallback on the wildcard one for server (it will generate a warning, but it will works and not hangs !)
 				export pathforcertiflocal="/etc/apache2"
 				export webCustomSSLCertificateCRT=$webSSLCertificateCRT
@@ -552,7 +557,7 @@ if [[ "$mode" == "rename" ]]; then
 				export CERTIFFORCUSTOMDOMAIN="with.sellyoursaas.com"
 			else
 				# We will use the custom cert file
-				export pathforcertiflocal="/home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt"
+				export pathforcertiflocal="${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt"
 				export webCustomSSLCertificateCRT="$fqn-custom.crt"
 				export webCustomSSLCertificateKEY="$fqn-custom.key"
 				export webCustomSSLCertificateIntermediate="$fqn-custom-intermediate.crt"
@@ -581,9 +586,9 @@ if [[ "$mode" == "rename" ]]; then
 		echo "cat $vhostfile | sed -e 's/__webAppDomain__/$customurl/g' | \
 				  sed -e 's/__webAppAliases__/$customurl/g' | \
 				  sed -e 's/__webAppLogName__/$instancename/g' | \
-                  sed -e 's;/etc/apache2/__webSSLCertificateCRT__;$pathforcertiflocal/$webCustomSSLCertificateCRT;g' | \
-                  sed -e 's;/etc/apache2/__webSSLCertificateKEY__;$pathforcertiflocal/$webCustomSSLCertificateKEY;g' | \
-                  sed -e 's;/etc/apache2/__webSSLCertificateIntermediate__;$pathforcertiflocal/$webCustomSSLCertificateIntermediate;g' | \
+                  sed -e 's;\(/etc/apache2/\)\{0,1\}__webSSLCertificateCRT__;$pathforcertiflocal/$webCustomSSLCertificateCRT;g' | \
+                  sed -e 's;\(/etc/apache2/\)\{0,1\}__webSSLCertificateKEY__;$pathforcertiflocal/$webCustomSSLCertificateKEY;g' | \
+                  sed -e 's;\(/etc/apache2/\)\{0,1\}__webSSLCertificateIntermediate__;$pathforcertiflocal/$webCustomSSLCertificateIntermediate;g' | \
 				  sed -e 's/__webAdminEmail__/$EMAILFROM/g' | \
 				  sed -e 's/__osUsername__/$osusername/g' | \
 				  sed -e 's/__osGroupname__/$osusername/g' | \
@@ -603,9 +608,9 @@ if [[ "$mode" == "rename" ]]; then
 		cat $vhostfile | sed -e "s/__webAppDomain__/$customurl/g" | \
 				  sed -e "s/__webAppAliases__/$customurl/g" | \
 				  sed -e "s/__webAppLogName__/$instancename/g" | \
-                  sed -e "s;/etc/apache2/__webSSLCertificateCRT__;$pathforcertiflocal/$webCustomSSLCertificateCRT;g" | \
-                  sed -e "s;/etc/apache2/__webSSLCertificateKEY__;$pathforcertiflocal/$webCustomSSLCertificateKEY;g" | \
-                  sed -e "s;/etc/apache2/__webSSLCertificateIntermediate__;$pathforcertiflocal/$webCustomSSLCertificateIntermediate;g" | \
+                  sed -e "s;\(/etc/apache2/\)\{0,1\}__webSSLCertificateCRT__;$pathforcertiflocal/$webCustomSSLCertificateCRT;g" | \
+                  sed -e "s;\(/etc/apache2/\)\{0,1\}__webSSLCertificateKEY__;$pathforcertiflocal/$webCustomSSLCertificateKEY;g" | \
+                  sed -e "s;\(/etc/apache2/\)\{0,1\}__webSSLCertificateIntermediate__;$pathforcertiflocal/$webCustomSSLCertificateIntermediate;g" | \
 				  sed -e "s/__webAdminEmail__/$EMAILFROM/g" | \
 				  sed -e "s/__osUsername__/$osusername/g" | \
 				  sed -e "s/__osGroupname__/$osusername/g" | \
@@ -785,7 +790,7 @@ if [[ "$mode" == "suspend" || $mode == "suspendmaintenance" || $mode == "suspend
 		echo `date +'%Y-%m-%d %H:%M:%S'`" ***** For instance in $targetdir/$osusername/$dbname and mode=suspend..., we create also a new custom virtual file named $fqn.custom.conf"
 
         export pathforcertifmaster="/home/admin/wwwroot/dolibarr_documents/sellyoursaas/crt"
-        export pathforcertiflocal="/home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt"
+        export pathforcertiflocal="${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt"
 
 		echo `date +'%Y-%m-%d %H:%M:%S'`" Check that SSL files for $fqn.custom exists to reuse them (CERTIFFORCUSTOMDOMAIN=$CERTIFFORCUSTOMDOMAIN)"
 
@@ -835,7 +840,26 @@ if [[ "$mode" == "suspend" || $mode == "suspendmaintenance" || $mode == "suspend
 			# We must create the custom CRT file using letsencrypt if not yet created
 			# Canceled: When we suspend, there is no need to generate the cert for the custom URL. Cert should already exists if a custom url has been defined.
 
-			if [[ ! -e /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$fqn-custom.crt ]]; then
+			export pathforcertiflocal="${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt"
+
+			# If no cached copy exists yet for this instance's custom domain, but a real
+			# Let's Encrypt certificate for the domain itself already exists (e.g. left
+			# over from a previous custom-URL setup that was removed then recreated),
+			# link it into the cache now instead of silently falling back to the
+			# wildcard below - the wildcard does not cover an external custom domain.
+			if [[ ! -e $pathforcertiflocal/$fqn-custom.crt ]]; then
+				if [[ -e /etc/letsencrypt/live/$customurl/cert.pem ]]; then
+					ln -fs /etc/letsencrypt/live/$customurl/cert.pem $pathforcertiflocal/$fqn-custom.crt
+					ln -fs /etc/letsencrypt/live/$customurl/privkey.pem $pathforcertiflocal/$fqn-custom.key
+					ln -fs /etc/letsencrypt/live/$customurl/fullchain.pem $pathforcertiflocal/$fqn-custom-intermediate.crt
+				elif [[ -e /etc/letsencrypt/live/www.$customurl/cert.pem ]]; then
+					ln -fs /etc/letsencrypt/live/www.$customurl/cert.pem $pathforcertiflocal/$fqn-custom.crt
+					ln -fs /etc/letsencrypt/live/www.$customurl/privkey.pem $pathforcertiflocal/$fqn-custom.key
+					ln -fs /etc/letsencrypt/live/www.$customurl/fullchain.pem $pathforcertiflocal/$fqn-custom-intermediate.crt
+				fi
+			fi
+
+			if [[ ! -e $pathforcertiflocal/$fqn-custom.crt ]]; then
 				# If custom cert not found, we fallback on the wildcard one for server (it will generate a warning, but it will works and not hangs !)
 				export pathforcertiflocal="/etc/apache2"
 				export webCustomSSLCertificateCRT=$webSSLCertificateCRT
@@ -844,7 +868,6 @@ if [[ "$mode" == "suspend" || $mode == "suspendmaintenance" || $mode == "suspend
 				export CERTIFFORCUSTOMDOMAIN="with.sellyoursaas.com"
 			else
 				# We will use the custom cert file
-				export pathforcertiflocal="/home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt"
 				export webCustomSSLCertificateCRT="$fqn-custom.crt"
 				export webCustomSSLCertificateKEY="$fqn-custom.key"
 				export webCustomSSLCertificateIntermediate="$fqn-custom-intermediate.crt"
@@ -873,9 +896,9 @@ if [[ "$mode" == "suspend" || $mode == "suspendmaintenance" || $mode == "suspend
 		echo "cat $vhostfiletouse | sed -e 's/__webAppDomain__/$customurl/g' | \
 				  sed -e 's/__webAppAliases__/$customurl/g' | \
 				  sed -e 's/__webAppLogName__/$instancename/g' | \
-                  sed -e 's;/etc/apache2/__webSSLCertificateCRT__;$pathforcertiflocal/$webCustomSSLCertificateCRT;g' | \
-                  sed -e 's;/etc/apache2/__webSSLCertificateKEY__;$pathforcertiflocal/$webCustomSSLCertificateKEY;g' | \
-                  sed -e 's;/etc/apache2/__webSSLCertificateIntermediate__;$pathforcertiflocal/$webCustomSSLCertificateIntermediate;g' | \
+                  sed -e 's;\(/etc/apache2/\)\{0,1\}__webSSLCertificateCRT__;$pathforcertiflocal/$webCustomSSLCertificateCRT;g' | \
+                  sed -e 's;\(/etc/apache2/\)\{0,1\}__webSSLCertificateKEY__;$pathforcertiflocal/$webCustomSSLCertificateKEY;g' | \
+                  sed -e 's;\(/etc/apache2/\)\{0,1\}__webSSLCertificateIntermediate__;$pathforcertiflocal/$webCustomSSLCertificateIntermediate;g' | \
 				  sed -e 's/__webAdminEmail__/$EMAILFROM/g' | \
 				  sed -e 's/__osUsername__/$osusername/g' | \
 				  sed -e 's/__osGroupname__/$osusername/g' | \
@@ -894,9 +917,9 @@ if [[ "$mode" == "suspend" || $mode == "suspendmaintenance" || $mode == "suspend
 		cat $vhostfiletouse | sed -e "s/__webAppDomain__/$customurl/g" | \
 				  sed -e "s/__webAppAliases__/$customurl/g" | \
 				  sed -e "s/__webAppLogName__/$instancename/g" | \
-                  sed -e "s;/etc/apache2/__webSSLCertificateCRT__;$pathforcertiflocal/$webCustomSSLCertificateCRT;g" | \
-                  sed -e "s;/etc/apache2/__webSSLCertificateKEY__;$pathforcertiflocal/$webCustomSSLCertificateKEY;g" | \
-                  sed -e "s;/etc/apache2/__webSSLCertificateIntermediate__;$pathforcertiflocal/$webCustomSSLCertificateIntermediate;g" | \
+                  sed -e "s;\(/etc/apache2/\)\{0,1\}__webSSLCertificateCRT__;$pathforcertiflocal/$webCustomSSLCertificateCRT;g" | \
+                  sed -e "s;\(/etc/apache2/\)\{0,1\}__webSSLCertificateKEY__;$pathforcertiflocal/$webCustomSSLCertificateKEY;g" | \
+                  sed -e "s;\(/etc/apache2/\)\{0,1\}__webSSLCertificateIntermediate__;$pathforcertiflocal/$webCustomSSLCertificateIntermediate;g" | \
 				  sed -e "s/__webAdminEmail__/$EMAILFROM/g" | \
 				  sed -e "s/__osUsername__/$osusername/g" | \
 				  sed -e "s/__osGroupname__/$osusername/g" | \
@@ -1027,7 +1050,7 @@ if [[ "$mode" == "unsuspend" ]]; then
 		echo `date +'%Y-%m-%d %H:%M:%S'`" ***** For instance in $targetdir/$osusername/$dbname and mode=unsuspend, we will create a new custom virtual name $fqn.custom"
 
         export pathforcertifmaster="/home/admin/wwwroot/dolibarr_documents/sellyoursaas/crt"
-        export pathforcertiflocal="/home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt"
+        export pathforcertiflocal="${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt"
 
 		echo `date +'%Y-%m-%d %H:%M:%S'`" Check that SSL files for $fqn.custom exists to reuse them (CERTIFFORCUSTOMDOMAIN=$CERTIFFORCUSTOMDOMAIN)"
 	
@@ -1077,15 +1100,34 @@ if [[ "$mode" == "unsuspend" ]]; then
 			# We must create the custom CRT file using letsencrypt if not yet created
 			# Canceled: When we unsuspend, there is no need to generate the cert for the custom URL. Cert should already exists if a custom url has been defined.
 
+			export pathforcertiflocal="${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt"
+
+			# If no cached copy exists yet for this instance's custom domain, but a real
+			# Let's Encrypt certificate for the domain itself already exists (e.g. left
+			# over from a previous custom-URL setup that was removed then recreated),
+			# link it into the cache now instead of silently falling back to the
+			# wildcard below - the wildcard does not cover an external custom domain.
+			if [[ ! -e $pathforcertiflocal/$fqn-custom.crt ]]; then
+				if [[ -e /etc/letsencrypt/live/$customurl/cert.pem ]]; then
+					ln -fs /etc/letsencrypt/live/$customurl/cert.pem $pathforcertiflocal/$fqn-custom.crt
+					ln -fs /etc/letsencrypt/live/$customurl/privkey.pem $pathforcertiflocal/$fqn-custom.key
+					ln -fs /etc/letsencrypt/live/$customurl/fullchain.pem $pathforcertiflocal/$fqn-custom-intermediate.crt
+				elif [[ -e /etc/letsencrypt/live/www.$customurl/cert.pem ]]; then
+					ln -fs /etc/letsencrypt/live/www.$customurl/cert.pem $pathforcertiflocal/$fqn-custom.crt
+					ln -fs /etc/letsencrypt/live/www.$customurl/privkey.pem $pathforcertiflocal/$fqn-custom.key
+					ln -fs /etc/letsencrypt/live/www.$customurl/fullchain.pem $pathforcertiflocal/$fqn-custom-intermediate.crt
+				fi
+			fi
+
 			# If custom cert not found, we fallback on the wildcard one for server (will generate a warning, but it will works !)
-			if [[ ! -e "/home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$fqn-custom.crt" ]]; then
+			if [[ ! -e $pathforcertiflocal/$fqn-custom.crt ]]; then
 				export pathforcertiflocal="/etc/apache2"
 	            export webCustomSSLCertificateCRT=$webSSLCertificateCRT
     	        export webCustomSSLCertificateKEY=$webSSLCertificateKEY
         	    export webCustomSSLCertificateIntermediate=$webSSLCertificateIntermediate
             	export CERTIFFORCUSTOMDOMAIN="with.sellyoursaas.com"
 			else
-				export pathforcertiflocal="/home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt"
+				export pathforcertiflocal="${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt"
 				export webCustomSSLCertificateCRT="$fqn-custom.crt"
 				export webCustomSSLCertificateKEY="$fqn-custom.key"
 				export webCustomSSLCertificateIntermediate="$fqn-custom-intermediate.crt"
@@ -1113,9 +1155,9 @@ if [[ "$mode" == "unsuspend" ]]; then
 		echo "cat $vhostfiletouse | sed -e 's/__webAppDomain__/$customurl/g' | \
 				  sed -e 's/__webAppAliases__/$customurl/g' | \
 				  sed -e 's/__webAppLogName__/$instancename/g' | \
-                  sed -e 's;/etc/apache2/__webSSLCertificateCRT__;$pathforcertiflocal/$webCustomSSLCertificateCRT;g' | \
-                  sed -e 's;/etc/apache2/__webSSLCertificateKEY__;$pathforcertiflocal/$webCustomSSLCertificateKEY;g' | \
-                  sed -e 's;/etc/apache2/__webSSLCertificateIntermediate__;$pathforcertiflocal/$webCustomSSLCertificateIntermediate;g' | \
+                  sed -e 's;\(/etc/apache2/\)\{0,1\}__webSSLCertificateCRT__;$pathforcertiflocal/$webCustomSSLCertificateCRT;g' | \
+                  sed -e 's;\(/etc/apache2/\)\{0,1\}__webSSLCertificateKEY__;$pathforcertiflocal/$webCustomSSLCertificateKEY;g' | \
+                  sed -e 's;\(/etc/apache2/\)\{0,1\}__webSSLCertificateIntermediate__;$pathforcertiflocal/$webCustomSSLCertificateIntermediate;g' | \
 				  sed -e 's/__webAdminEmail__/$EMAILFROM/g' | \
 				  sed -e 's/__osUsername__/$osusername/g' | \
 				  sed -e 's/__osGroupname__/$osusername/g' | \
@@ -1133,9 +1175,9 @@ if [[ "$mode" == "unsuspend" ]]; then
 		cat $vhostfiletouse | sed -e "s/__webAppDomain__/$customurl/g" | \
 				  sed -e "s/__webAppAliases__/$customurl/g" | \
 				  sed -e "s/__webAppLogName__/$instancename/g" | \
-                  sed -e "s;/etc/apache2/__webSSLCertificateCRT__;$pathforcertiflocal/$webCustomSSLCertificateCRT;g" | \
-                  sed -e "s;/etc/apache2/__webSSLCertificateKEY__;$pathforcertiflocal/$webCustomSSLCertificateKEY;g" | \
-                  sed -e "s;/etc/apache2/__webSSLCertificateIntermediate__;$pathforcertiflocal/$webCustomSSLCertificateIntermediate;g" | \
+                  sed -e "s;\(/etc/apache2/\)\{0,1\}__webSSLCertificateCRT__;$pathforcertiflocal/$webCustomSSLCertificateCRT;g" | \
+                  sed -e "s;\(/etc/apache2/\)\{0,1\}__webSSLCertificateKEY__;$pathforcertiflocal/$webCustomSSLCertificateKEY;g" | \
+                  sed -e "s;\(/etc/apache2/\)\{0,1\}__webSSLCertificateIntermediate__;$pathforcertiflocal/$webCustomSSLCertificateIntermediate;g" | \
 				  sed -e "s/__webAdminEmail__/$EMAILFROM/g" | \
 				  sed -e "s/__osUsername__/$osusername/g" | \
 				  sed -e "s/__osGroupname__/$osusername/g" | \


### PR DESCRIPTION
## Context

Split out of #491 per review feedback (PR too large) - these are standalone
bug fixes unrelated to the PHP-FPM feature, found while working on that
branch.

## What's included

- Remote agent signature check broke on requests with fewer than 50
  parameters (hardcoded offset instead of computing it from the actual
  parameter count).
- SSL cert path substitution in `action_suspend_unsuspend.sh` never matched
  in rename mode, which could leave an invalid `.custom.conf` blocking
  `apache2ctl configtest` (and thus all future reloads) for the whole
  server. Also missing `mkdir -p`, and orphaned cert cleanup on rename.
- Undefined `$website` variable in the customer-facing custom URL form
  (fatal error on submission).
- New contract lines added from myaccount options always landed as line 1
  instead of the last line (`Contrat::addline` rang not set).