### PR TITLE
Fix php-fpm ini config gaps and add PHP 8.2/8.4 support to launch_install_check.yml

### DIFF
--- a/scripts/ansible/launch_install_check.yml
+++ b/scripts/ansible/launch_install_check.yml
@@ -7,7 +7,9 @@
 # ansible-playbook -K launch_install_check.yml -i hosts-xxx -e 'target=targethost php74=1 apache=1'
 # ansible-playbook -K launch_install_check.yml -i hosts-xxx -e 'target=targethost php80=1 apache=1'
 # ansible-playbook -K launch_install_check.yml -i hosts-xxx -e 'target=targethost php81=1 apache=1'
+# ansible-playbook -K launch_install_check.yml -i hosts-xxx -e 'target=targethost php82=1 apache=1'
 # ansible-playbook -K launch_install_check.yml -i hosts-xxx -e 'target=targethost php83=1 apache=1'
+# ansible-playbook -K launch_install_check.yml -i hosts-xxx -e 'target=targethost php84=1 apache=1'
 #
 
 
@@ -269,6 +271,50 @@
       var: command_output
 
 
+  ##### For PHP 8.2
+  - name: Launch apt for php 8.2 packages
+    apt:
+      pkg:
+      - php8.2
+      - php8.2-cli
+      - libapache2-mod-php8.2
+      #- php8.2-fpm
+      - php8.2-gd
+      - php8.2-imap
+      - php8.2-ldap
+      - php8.2-mysql
+      - php8.2-curl
+      - php8.2-memcached
+      - php8.2-imagick
+      - php8.2-intl
+      - php8.2-xml
+      - php8.2-zip
+      - php8.2-bz2
+      - php8.2-ssh2
+      - php8.2-mbstring
+      - php8.2-dev
+      - php8.2-soap
+      - php8.2-tidy
+    register: command_output
+    when:
+      - php82 is defined
+
+  - debug:
+      var: command_output
+
+  - name: Launch apt for GLPI packages
+    apt:
+      pkg:
+      - php8.2-readline
+      - php8.2-xmlrpc
+    register: command_output
+    when:
+      - php82 is defined
+
+  - debug:
+      var: command_output
+
+
   ##### For PHP 8.3
   - name: Launch apt for php 8.3 packages
     apt:
@@ -308,6 +354,50 @@
     register: command_output
     when:
       - php83 is defined
+
+  - debug:
+      var: command_output
+
+
+  ##### For PHP 8.4
+  - name: Launch apt for php 8.4 packages
+    apt:
+      pkg:
+      - php8.4
+      - php8.4-cli
+      - libapache2-mod-php8.4
+      #- php8.4-fpm
+      - php8.4-gd
+      - php8.4-imap
+      - php8.4-ldap
+      - php8.4-mysql
+      - php8.4-curl
+      - php8.4-memcached
+      - php8.4-imagick
+      - php8.4-intl
+      - php8.4-xml
+      - php8.4-zip
+      - php8.4-bz2
+      - php8.4-ssh2
+      - php8.4-mbstring
+      - php8.4-dev
+      - php8.4-soap
+      - php8.4-tidy
+    register: command_output
+    when:
+      - php84 is defined
+
+  - debug:
+      var: command_output
+
+  - name: Launch apt for GLPI packages
+    apt:
+      pkg:
+      - php8.4-readline
+      - php8.4-xmlrpc
+    register: command_output
+    when:
+      - php84 is defined
 
   - debug:
       var: command_output
@@ -474,6 +564,35 @@
     ini_file:
       path: /etc/php/7.0/cli/php.ini
       section: PHP
+      option: mail.log
+      value: /var/log/phpmail.log
+    when:
+      - php70 is defined
+
+  ##### fpm/php.ini
+  - name: Check or update auto_prepend_file fpm/php.ini
+    ini_file:
+      path: /etc/php/7.0/fpm/php.ini
+      section: PHP
+      option: auto_prepend_file
+      value: /usr/local/bin/phpsendmailprepend.php
+      backup: yes
+    when:
+      - php70 is defined
+
+  - name: Check or update sendmail_path fpm/php.ini
+    ini_file:
+      path: /etc/php/7.0/fpm/php.ini
+      section: 'mail function'
+      option: sendmail_path
+      value: /usr/local/bin/phpsendmail.php
+    when:
+      - php70 is defined
+
+  - name: Check or update mail.log fpm/php.ini
+    ini_file:
+      path: /etc/php/7.0/fpm/php.ini
+      section: 'mail function'
       option: mail.log
       value: /var/log/phpmail.log
     when:
@@ -653,6 +772,35 @@
     when:
       - php74 is defined
 
+  ##### fpm/php.ini
+  - name: Check or update auto_prepend_file fpm/php.ini
+    ini_file:
+      path: /etc/php/7.4/fpm/php.ini
+      section: PHP
+      option: auto_prepend_file
+      value: /usr/local/bin/phpsendmailprepend.php
+      backup: yes
+    when:
+      - php74 is defined
+
+  - name: Check or update sendmail_path fpm/php.ini
+    ini_file:
+      path: /etc/php/7.4/fpm/php.ini
+      section: 'mail function'
+      option: sendmail_path
+      value: /usr/local/bin/phpsendmail.php
+    when:
+      - php74 is defined
+
+  - name: Check or update mail.log fpm/php.ini
+    ini_file:
+      path: /etc/php/7.4/fpm/php.ini
+      section: 'mail function'
+      option: mail.log
+      value: /var/log/phpmail.log
+    when:
+      - php74 is defined
+
   - name: Set PHP version for CLI
     community.general.alternatives:
       name: php
@@ -822,6 +970,35 @@
     ini_file:
       path: /etc/php/8.0/cli/php.ini
       section: PHP
+      option: mail.log
+      value: /var/log/phpmail.log
+    when:
+      - php80 is defined
+
+  ##### fpm/php.ini
+  - name: Check or update auto_prepend_file fpm/php.ini
+    ini_file:
+      path: /etc/php/8.0/fpm/php.ini
+      section: PHP
+      option: auto_prepend_file
+      value: /usr/local/bin/phpsendmailprepend.php
+      backup: yes
+    when:
+      - php80 is defined
+
+  - name: Check or update sendmail_path fpm/php.ini
+    ini_file:
+      path: /etc/php/8.0/fpm/php.ini
+      section: 'mail function'
+      option: sendmail_path
+      value: /usr/local/bin/phpsendmail.php
+    when:
+      - php80 is defined
+
+  - name: Check or update mail.log fpm/php.ini
+    ini_file:
+      path: /etc/php/8.0/fpm/php.ini
+      section: 'mail function'
       option: mail.log
       value: /var/log/phpmail.log
     when:
@@ -1017,6 +1194,35 @@
     when:
       - php81 is defined
 
+  ##### fpm/php.ini
+  - name: Check or update auto_prepend_file fpm/php.ini
+    ini_file:
+      path: /etc/php/8.1/fpm/php.ini
+      section: PHP
+      option: auto_prepend_file
+      value: /usr/local/bin/phpsendmailprepend.php
+      backup: yes
+    when:
+      - php81 is defined
+
+  - name: Check or update sendmail_path fpm/php.ini
+    ini_file:
+      path: /etc/php/8.1/fpm/php.ini
+      section: 'mail function'
+      option: sendmail_path
+      value: /usr/local/bin/phpsendmail.php
+    when:
+      - php81 is defined
+
+  - name: Check or update mail.log fpm/php.ini
+    ini_file:
+      path: /etc/php/8.1/fpm/php.ini
+      section: 'mail function'
+      option: mail.log
+      value: /var/log/phpmail.log
+    when:
+      - php81 is defined
+
   - name: Disable old PHP on Apache
     command: a2dismod php7.0 php7.2 php7.3 php7.4 php8.0
     ignore_errors: true
@@ -1041,6 +1247,225 @@
       var: phpversionmodified.changed
 
 
+  ##### PHP 8.2 apache2/php.ini
+  - name: Check or update upload_max_filesize php.ini
+    ini_file:
+      path: /etc/php/8.2/apache2/php.ini
+      section: PHP
+      option: upload_max_filesize
+      value: 25M
+      backup: yes
+    when:
+      - php82 is defined
+
+  - name: Check or update post_max_size php.ini
+    ini_file:
+      path: /etc/php/8.2/apache2/php.ini
+      section: PHP
+      option: post_max_size
+      value: 30M
+    when:
+      - php82 is defined
+
+  - name: Check or update max_input_vars php.ini
+    ini_file:
+      path: /etc/php/8.2/apache2/php.ini
+      section: PHP
+      option: max_input_vars
+      value: '4000'
+    when:
+      - php82 is defined
+
+  - name: Check or update memory_limit php.ini
+    ini_file:
+      path: /etc/php/8.2/apache2/php.ini
+      section: PHP
+      option: memory_limit
+      value: 256M
+    when:
+      - php82 is defined
+
+  - name: Check or update disable_functions php.ini
+    ini_file:
+      path: /etc/php/8.2/apache2/php.ini
+      section: PHP
+      option: disable_functions
+      value: "pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_get_handler,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,pcntl_async_signals,pcntl_unshare,passthru,system,proc_open,dl,apache_note,apache_setenv,show_source,virtual"
+    when:
+      - php82 is defined
+
+  - name: Check or update session.gc_maxlifetime php.ini
+    ini_file:
+      path: /etc/php/8.2/apache2/php.ini
+      section: Session
+      option: session.gc_maxlifetime
+      value: '14400'
+    when:
+      - php82 is defined
+
+  - name: Check or update session.use_strict_mode php.ini
+    ini_file:
+      path: /etc/php/8.2/apache2/php.ini
+      section: Session
+      option: session.use_strict_mode
+      value: '1'
+    when:
+      - php82 is defined
+
+  - name: Check or update session.use_only_cookies php.ini
+    ini_file:
+      path: /etc/php/8.2/apache2/php.ini
+      section: Session
+      option: session.use_only_cookies
+      value: '1'
+    when:
+      - php82 is defined
+
+  - name: Check or update session.cookie_httponly php.ini
+    ini_file:
+      path: /etc/php/8.2/apache2/php.ini
+      section: Session
+      option: session.cookie_httponly
+      value: '1'
+    when:
+      - php82 is defined
+
+  - name: Check or update session.cookie_samesite php.ini
+    ini_file:
+      path: /etc/php/8.2/apache2/php.ini
+      section: Session
+      option: session.cookie_samesite
+      value: Lax
+    when:
+      - php82 is defined
+
+  - name: Check or update auto_prepend_file php.ini
+    ini_file:
+      path: /etc/php/8.2/apache2/php.ini
+      section: PHP
+      option: auto_prepend_file
+      value: /usr/local/bin/phpsendmailprepend.php
+    when:
+      - php82 is defined
+
+  - name: Check or update sendmail_path php.ini
+    ini_file:
+      path: /etc/php/8.2/apache2/php.ini
+      section: 'mail function'
+      option: sendmail_path
+      value: /usr/local/bin/phpsendmail.php
+    when:
+      - php82 is defined
+
+  - name: Check or update mail.log php.ini
+    ini_file:
+      path: /etc/php/8.2/apache2/php.ini
+      section: 'mail function'
+      option: mail.log
+      value: /var/log/phpmail.log
+    when:
+      - php82 is defined
+
+  - name: Check or update opcache.memory_consumption php.ini
+    ini_file:
+      path: /etc/php/8.2/apache2/php.ini
+      section: opcache
+      option: opcache.memory_consumption
+      value: '1024'
+    when:
+      - php82 is defined
+
+  - name: Check or update opcache.max_accelerated_files php.ini
+    ini_file:
+      path: /etc/php/8.2/apache2/php.ini
+      section: opcache
+      option: opcache.max_accelerated_files
+      value: '100000'
+    when:
+      - php82 is defined
+
+  ##### cli/php.ini
+  - name: Check or update auto_prepend_file cli/php.ini
+    ini_file:
+      path: /etc/php/8.2/cli/php.ini
+      section: PHP
+      option: auto_prepend_file
+      value: /usr/local/bin/phpsendmailprepend.php
+      backup: yes
+    when:
+      - php82 is defined
+
+  - name: Check or update sendmail_path cli/php.ini
+    ini_file:
+      path: /etc/php/8.2/cli/php.ini
+      section: PHP
+      option: sendmail_path
+      value: /usr/local/bin/phpsendmail.php
+    when:
+      - php82 is defined
+
+  - name: Check or update mail.log cli/php.ini
+    ini_file:
+      path: /etc/php/8.2/cli/php.ini
+      section: PHP
+      option: mail.log
+      value: /var/log/phpmail.log
+    when:
+      - php82 is defined
+
+  ##### fpm/php.ini
+  - name: Check or update auto_prepend_file fpm/php.ini
+    ini_file:
+      path: /etc/php/8.2/fpm/php.ini
+      section: PHP
+      option: auto_prepend_file
+      value: /usr/local/bin/phpsendmailprepend.php
+      backup: yes
+    when:
+      - php82 is defined
+
+  - name: Check or update sendmail_path fpm/php.ini
+    ini_file:
+      path: /etc/php/8.2/fpm/php.ini
+      section: 'mail function'
+      option: sendmail_path
+      value: /usr/local/bin/phpsendmail.php
+    when:
+      - php82 is defined
+
+  - name: Check or update mail.log fpm/php.ini
+    ini_file:
+      path: /etc/php/8.2/fpm/php.ini
+      section: 'mail function'
+      option: mail.log
+      value: /var/log/phpmail.log
+    when:
+      - php82 is defined
+
+  - name: Disable old PHP on Apache
+    command: a2dismod php7.0 php7.2 php7.3 php7.4 php8.0 php8.1
+    ignore_errors: true
+    when:
+      - php82 is defined
+
+  - name: Activates PHP on Apache
+    command: a2enmod php8.2
+    when:
+      - php82 is defined
+
+  - name: Set PHP version for CLI
+    community.general.alternatives:
+      name: php
+      path: /usr/bin/php8.2
+    register: phpversionmodified
+    notify: restart-apache
+    when:
+      - php82 is defined
+
+  - debug:
+      var: phpversionmodified.changed
+
+
   ##### PHP 8.3 apache2/php.ini
   - name: Check or update upload_max_filesize php.ini
     ini_file:
@@ -1050,7 +1475,7 @@
       value: 25M
       backup: yes
     when:
-      - php81 is defined
+      - php83 is defined
 
   - name: Check or update post_max_size php.ini
     ini_file:
@@ -1059,7 +1484,7 @@
       option: post_max_size
       value: 30M
     when:
-      - php81 is defined
+      - php83 is defined
 
   - name: Check or update max_input_vars php.ini
     ini_file:
@@ -1068,7 +1493,7 @@
       option: max_input_vars
       value: '4000'
     when:
-      - php81 is defined
+      - php83 is defined
 
   - name: Check or update memory_limit php.ini
     ini_file:
@@ -1077,7 +1502,7 @@
       option: memory_limit
       value: 256M
     when:
-      - php81 is defined
+      - php83 is defined
 
   - name: Check or update disable_functions php.ini
     ini_file:
@@ -1086,7 +1511,7 @@
       option: disable_functions
       value: "pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_get_handler,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,pcntl_async_signals,pcntl_unshare,passthru,system,proc_open,dl,apache_note,apache_setenv,show_source,virtual"
     when:
-      - php81 is defined
+      - php83 is defined
 
   - name: Check or update session.gc_maxlifetime php.ini
     ini_file:
@@ -1095,7 +1520,7 @@
       option: session.gc_maxlifetime
       value: '14400'
     when:
-      - php81 is defined
+      - php83 is defined
 
   - name: Check or update session.use_strict_mode php.ini
     ini_file:
@@ -1104,16 +1529,16 @@
       option: session.use_strict_mode
       value: '1'
     when:
-      - php81 is defined
+      - php83 is defined
 
   - name: Check or update session.use_only_cookies php.ini
     ini_file:
-      path: /etc/php/8.0/apache2/php.ini
+      path: /etc/php/8.3/apache2/php.ini
       section: Session
       option: session.use_only_cookies
       value: '1'
     when:
-      - php80 is defined
+      - php83 is defined
 
   - name: Check or update session.cookie_httponly php.ini
     ini_file:
@@ -1122,7 +1547,7 @@
       option: session.cookie_httponly
       value: '1'
     when:
-      - php81 is defined
+      - php83 is defined
 
   - name: Check or update session.cookie_samesite php.ini
     ini_file:
@@ -1131,16 +1556,16 @@
       option: session.cookie_samesite
       value: Lax
     when:
-      - php81 is defined
+      - php83 is defined
 
   - name: Check or update auto_prepend_file php.ini
     ini_file:
-      path: /etc/php/8.0/apache2/php.ini
+      path: /etc/php/8.3/apache2/php.ini
       section: PHP
       option: auto_prepend_file
       value: /usr/local/bin/phpsendmailprepend.php
     when:
-      - php80 is defined
+      - php83 is defined
 
   - name: Check or update sendmail_path php.ini
     ini_file:
@@ -1149,7 +1574,7 @@
       option: sendmail_path
       value: /usr/local/bin/phpsendmail.php
     when:
-      - php81 is defined
+      - php83 is defined
 
   - name: Check or update mail.log php.ini
     ini_file:
@@ -1158,7 +1583,7 @@
       option: mail.log
       value: /var/log/phpmail.log
     when:
-      - php81 is defined
+      - php83 is defined
 
   - name: Check or update opcache.memory_consumption php.ini
     ini_file:
@@ -1167,7 +1592,7 @@
       option: opcache.memory_consumption
       value: '1024'
     when:
-      - php81 is defined
+      - php83 is defined
 
   - name: Check or update opcache.max_accelerated_files php.ini
     ini_file:
@@ -1176,7 +1601,7 @@
       option: opcache.max_accelerated_files
       value: '100000'
     when:
-      - php81 is defined
+      - php83 is defined
 
   ##### cli/php.ini
   - name: Check or update auto_prepend_file cli/php.ini
@@ -1187,7 +1612,7 @@
       value: /usr/local/bin/phpsendmailprepend.php
       backup: yes
     when:
-      - php81 is defined
+      - php83 is defined
 
   - name: Check or update sendmail_path cli/php.ini
     ini_file:
@@ -1196,7 +1621,7 @@
       option: sendmail_path
       value: /usr/local/bin/phpsendmail.php
     when:
-      - php81 is defined
+      - php83 is defined
 
   - name: Check or update mail.log cli/php.ini
     ini_file:
@@ -1205,13 +1630,42 @@
       option: mail.log
       value: /var/log/phpmail.log
     when:
-      - php81 is defined
+      - php83 is defined
+
+  ##### fpm/php.ini
+  - name: Check or update auto_prepend_file fpm/php.ini
+    ini_file:
+      path: /etc/php/8.3/fpm/php.ini
+      section: PHP
+      option: auto_prepend_file
+      value: /usr/local/bin/phpsendmailprepend.php
+      backup: yes
+    when:
+      - php83 is defined
+
+  - name: Check or update sendmail_path fpm/php.ini
+    ini_file:
+      path: /etc/php/8.3/fpm/php.ini
+      section: 'mail function'
+      option: sendmail_path
+      value: /usr/local/bin/phpsendmail.php
+    when:
+      - php83 is defined
+
+  - name: Check or update mail.log fpm/php.ini
+    ini_file:
+      path: /etc/php/8.3/fpm/php.ini
+      section: 'mail function'
+      option: mail.log
+      value: /var/log/phpmail.log
+    when:
+      - php83 is defined
 
   - name: Disable old PHP on Apache
-    command: a2dismod php7.0 php7.2 php7.3 php7.4 php8.0 php8.1
+    command: a2dismod php7.0 php7.2 php7.3 php7.4 php8.0 php8.1 php8.2
     ignore_errors: true
     when:
-      - php81 is defined
+      - php83 is defined
 
   - name: Activates PHP on Apache
     command: a2enmod php8.3
@@ -1226,6 +1680,225 @@
     notify: restart-apache
     when:
       - php83 is defined
+
+  - debug:
+      var: phpversionmodified.changed
+
+
+  ##### PHP 8.4 apache2/php.ini
+  - name: Check or update upload_max_filesize php.ini
+    ini_file:
+      path: /etc/php/8.4/apache2/php.ini
+      section: PHP
+      option: upload_max_filesize
+      value: 25M
+      backup: yes
+    when:
+      - php84 is defined
+
+  - name: Check or update post_max_size php.ini
+    ini_file:
+      path: /etc/php/8.4/apache2/php.ini
+      section: PHP
+      option: post_max_size
+      value: 30M
+    when:
+      - php84 is defined
+
+  - name: Check or update max_input_vars php.ini
+    ini_file:
+      path: /etc/php/8.4/apache2/php.ini
+      section: PHP
+      option: max_input_vars
+      value: '4000'
+    when:
+      - php84 is defined
+
+  - name: Check or update memory_limit php.ini
+    ini_file:
+      path: /etc/php/8.4/apache2/php.ini
+      section: PHP
+      option: memory_limit
+      value: 256M
+    when:
+      - php84 is defined
+
+  - name: Check or update disable_functions php.ini
+    ini_file:
+      path: /etc/php/8.4/apache2/php.ini
+      section: PHP
+      option: disable_functions
+      value: "pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_get_handler,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,pcntl_async_signals,pcntl_unshare,passthru,system,proc_open,dl,apache_note,apache_setenv,show_source,virtual"
+    when:
+      - php84 is defined
+
+  - name: Check or update session.gc_maxlifetime php.ini
+    ini_file:
+      path: /etc/php/8.4/apache2/php.ini
+      section: Session
+      option: session.gc_maxlifetime
+      value: '14400'
+    when:
+      - php84 is defined
+
+  - name: Check or update session.use_strict_mode php.ini
+    ini_file:
+      path: /etc/php/8.4/apache2/php.ini
+      section: Session
+      option: session.use_strict_mode
+      value: '1'
+    when:
+      - php84 is defined
+
+  - name: Check or update session.use_only_cookies php.ini
+    ini_file:
+      path: /etc/php/8.4/apache2/php.ini
+      section: Session
+      option: session.use_only_cookies
+      value: '1'
+    when:
+      - php84 is defined
+
+  - name: Check or update session.cookie_httponly php.ini
+    ini_file:
+      path: /etc/php/8.4/apache2/php.ini
+      section: Session
+      option: session.cookie_httponly
+      value: '1'
+    when:
+      - php84 is defined
+
+  - name: Check or update session.cookie_samesite php.ini
+    ini_file:
+      path: /etc/php/8.4/apache2/php.ini
+      section: Session
+      option: session.cookie_samesite
+      value: Lax
+    when:
+      - php84 is defined
+
+  - name: Check or update auto_prepend_file php.ini
+    ini_file:
+      path: /etc/php/8.4/apache2/php.ini
+      section: PHP
+      option: auto_prepend_file
+      value: /usr/local/bin/phpsendmailprepend.php
+    when:
+      - php84 is defined
+
+  - name: Check or update sendmail_path php.ini
+    ini_file:
+      path: /etc/php/8.4/apache2/php.ini
+      section: 'mail function'
+      option: sendmail_path
+      value: /usr/local/bin/phpsendmail.php
+    when:
+      - php84 is defined
+
+  - name: Check or update mail.log php.ini
+    ini_file:
+      path: /etc/php/8.4/apache2/php.ini
+      section: 'mail function'
+      option: mail.log
+      value: /var/log/phpmail.log
+    when:
+      - php84 is defined
+
+  - name: Check or update opcache.memory_consumption php.ini
+    ini_file:
+      path: /etc/php/8.4/apache2/php.ini
+      section: opcache
+      option: opcache.memory_consumption
+      value: '1024'
+    when:
+      - php84 is defined
+
+  - name: Check or update opcache.max_accelerated_files php.ini
+    ini_file:
+      path: /etc/php/8.4/apache2/php.ini
+      section: opcache
+      option: opcache.max_accelerated_files
+      value: '100000'
+    when:
+      - php84 is defined
+
+  ##### cli/php.ini
+  - name: Check or update auto_prepend_file cli/php.ini
+    ini_file:
+      path: /etc/php/8.4/cli/php.ini
+      section: PHP
+      option: auto_prepend_file
+      value: /usr/local/bin/phpsendmailprepend.php
+      backup: yes
+    when:
+      - php84 is defined
+
+  - name: Check or update sendmail_path cli/php.ini
+    ini_file:
+      path: /etc/php/8.4/cli/php.ini
+      section: PHP
+      option: sendmail_path
+      value: /usr/local/bin/phpsendmail.php
+    when:
+      - php84 is defined
+
+  - name: Check or update mail.log cli/php.ini
+    ini_file:
+      path: /etc/php/8.4/cli/php.ini
+      section: PHP
+      option: mail.log
+      value: /var/log/phpmail.log
+    when:
+      - php84 is defined
+
+  ##### fpm/php.ini
+  - name: Check or update auto_prepend_file fpm/php.ini
+    ini_file:
+      path: /etc/php/8.4/fpm/php.ini
+      section: PHP
+      option: auto_prepend_file
+      value: /usr/local/bin/phpsendmailprepend.php
+      backup: yes
+    when:
+      - php84 is defined
+
+  - name: Check or update sendmail_path fpm/php.ini
+    ini_file:
+      path: /etc/php/8.4/fpm/php.ini
+      section: 'mail function'
+      option: sendmail_path
+      value: /usr/local/bin/phpsendmail.php
+    when:
+      - php84 is defined
+
+  - name: Check or update mail.log fpm/php.ini
+    ini_file:
+      path: /etc/php/8.4/fpm/php.ini
+      section: 'mail function'
+      option: mail.log
+      value: /var/log/phpmail.log
+    when:
+      - php84 is defined
+
+  - name: Disable old PHP on Apache
+    command: a2dismod php7.0 php7.2 php7.3 php7.4 php8.0 php8.1 php8.2 php8.3
+    ignore_errors: true
+    when:
+      - php84 is defined
+
+  - name: Activates PHP on Apache
+    command: a2enmod php8.4
+    when:
+      - php84 is defined
+
+  - name: Set PHP version for CLI
+    community.general.alternatives:
+      name: php
+      path: /usr/bin/php8.4
+    register: phpversionmodified
+    notify: restart-apache
+    when:
+      - php84 is defined
 
   - debug:
       var: phpversionmodified.changed

--- a/scripts/desktop_install_check.sh
+++ b/scripts/desktop_install_check.sh
@@ -15,7 +15,7 @@ export YELLOW='\033[0;33m'
 
 
 if [ "x$1" == "x" ]; then
-   echo "Usage:   $0  hostfile  [hostgrouporname]  (apache|php70|php72|php74|php80|php81|php82|php83)"
+   echo "Usage:   $0  hostfile  [hostgrouporname]  (apache|php70|php72|php74|php80|php81|php82|php83|php84)"
    echo "         [hostgrouporname] can be 'master', 'deployment' or list separated with comma like 'master,deployment' (default)"
    echo "Example: $0  myhostfile  master,deployment"
    echo "Example: $0  myhostfile  withX.mysellyoursaasdomain.com"
@@ -47,6 +47,12 @@ if [ "x$3" == "xphp81" ]; then
 fi
 if [ "x$3" == "xphp82" ]; then
 	php82=1
+fi
+if [ "x$3" == "xphp83" ]; then
+	php83=1
+fi
+if [ "x$3" == "xphp84" ]; then
+	php84=1
 fi
 if [ "x$3" == "xapache" ]; then
 	apache=1
@@ -87,6 +93,8 @@ elif [ "x$php82" == "x1" ]; then
 	command='ansible-playbook -K launch_install_check.yml -i hosts-'$1' -e "target='$target' php82='1'"'
 elif [ "x$php83" == "x1" ]; then
 	command='ansible-playbook -K launch_install_check.yml -i hosts-'$1' -e "target='$target' php83='1'"'
+elif [ "x$php84" == "x1" ]; then
+	command='ansible-playbook -K launch_install_check.yml -i hosts-'$1' -e "target='$target' php84='1'"'
 elif [ "x$apache" == "x1" ]; then
 	command='ansible-playbook -K launch_install_check.yml -i hosts-'$1' -e "target='$target' apache='1'"'
 else


### PR DESCRIPTION
## Summary
- `auto_prepend_file`, `sendmail_path` and `mail.log` were only ever applied to `apache2/php.ini` and `cli/php.ini` in launch_install_check.yml, never to `fpm/php.ini` - add the matching fpm tasks for every PHP version already handled (7.0, 7.4, 8.0, 8.1, 8.3).
- Add full PHP 8.2 and PHP 8.4 version blocks (apt packages, apache2/cli/fpm php.ini config, module enable/disable), and make the "disable old php modules" step cumulative across versions.
- Fix a pre-existing copy-paste bug in the PHP 8.3 section: several `when` conditions and two `path:` values were still referencing php8.0/php8.1 instead of php8.3.
- `desktop_install_check.sh`: the php83 flag was referenced in the command-building branch but never actually assigned from `$3`, so passing `php83` as the version argument silently fell through to the default branch. Also added `php82`/`php84` to the usage line.

## Test plan
- [x] YAML validated with `ruby -ryaml`
- [x] `bash -n` on the wrapper script
- [x] Dry-run (`--check --diff`) against a real test host with `-e 'php84=1'` / `php83=1` / `php82=1` - confirmed the fpm tasks detect and would fix the missing `auto_prepend_file`/`sendmail_path` on that host's existing PHP 8.4 fpm config, and correctly create fresh php.ini files for the not-yet-installed PHP 8.2. No regression on any other task; failures hit were pre-existing, unrelated host conditions (a `secureBash`/`dash` mismatch check further down the playbook, and a known ansible check-mode limitation where a simulated apt install can't be reflected by a later task in the same check-mode run).