### PR TITLE
Add deploy/suspend/undeploy lifecycle integration for per-instance PHP-FPM (2/3, split from #491)

### DIFF
--- a/doc/Documentation SellYourSaas - Master and Deployment Servers - EN.asciidoc
+++ b/doc/Documentation SellYourSaas - Master and Deployment Servers - EN.asciidoc
@@ -2912,7 +2912,7 @@ executables = /usr/bin/groups
 
 [php]
 comment = The PHP Interpreter and Libraries
-executables = /usr/bin/php, /usr/bin/php7.4, /usr/bin/php7.3, /usr/bin/php7.2, /usr/bin/php5.6
+executables = /usr/bin/php, /usr/bin/php8.1, /usr/bin/php8.2, /usr/bin/php8.3, /usr/bin/php8.4
 directories = /usr/lib/php, /usr/share/php, /usr/share/php, /etc/php, /usr/share/php-geshi, /usr/share/zoneinfo
 includesections = env
 
@@ -2923,9 +2923,16 @@ executables = /usr/bin/env
 [mysqlclient]
 comment = mysql client
 executables = /usr/bin/mysql, /usr/bin/mysqldump
-paths = /usr/lib/x86_64-linux-gnu/libmysqlclient.so.21
+paths = /usr/lib/x86_64-linux-gnu/libmariadb.so.3
 regularfiles = /etc/mysql/my.cf, /etc/mysql/conf.d/, /etc/mysql/mariadb.conf.d/
+
+[acl]
+comment = ACL utilities (needed on mpm_event/php-fpm servers so Apache, running as a single
+  shared www-data user, can still read the instance's own htdocs static files)
+paths = /usr/bin/setfacl, /usr/bin/getfacl
 ---------------
+
+Only list the `executables` (php and mysqlclient libs) that actually exist on this server - `ls /usr/bin/php*` and `ldconfig -p | grep libmariadb` first. When adding or removing a PHP-FPM version on the server later (see the PHP-FPM per-instance section), update this list and rebuild the jail template (next section) so SSH/SFTP users get a matching `phpX.Y` binary for their instance's version.
 
 * Add this to the end of the config file /etc/jailkit/jk_chrootsh.ini
 
@@ -2946,7 +2953,7 @@ mkdir /home/jail/chroot/template
 
 [source,bash]
 ---------------
-jk_init -c /etc/jailkit/jk_init.ini -j /home/jail/chroot/template extendedshell limitedshell groups sftp rsync editors git php mysqlclient
+jk_init -c /etc/jailkit/jk_init.ini -j /home/jail/chroot/template extendedshell limitedshell groups sftp rsync editors git php mysqlclient acl
 mkdir /home/jail/chroot/template/home
 mkdir /home/jail/chroot/template/tmp
 chmod 1777 /home/jail/chroot/template/tmp
@@ -2956,7 +2963,9 @@ In this example the commonjail.tgz template will be used to create the chroot/ja
 
 and the privatejail.tgz template will be used to create private chroot/jail (eg. /home/jail/chroot/osuxxxxx)
 
-* Create your tgz which will be used to install the private chroot/jail and reinstall the common chroot/jail if necessary
+commonjail.tgz and privatejail.tgz are packaged from the exact same `template` directory - they are the same content under two names, one used for the shared jail and one for a per-user private jail, not two different builds.
+
+* Create your tgz which will be used to install the private chroot/jail and reinstall the common chroot/jail if necessary. Use `--zstd` instead of `-z` if `usecompressformatforarchive=zstd` in /etc/sellyoursaas.conf (name the files `.tar.zst` instead of `.tgz` in that case, and everywhere below)
 
 [source,bash]
 ---------------
@@ -2970,6 +2979,13 @@ tar czf privatejail.tgz template
 [source,bash]
 ---------------
 mv commonjail.tgz privatejail.tgz /home/admin/wwwroot/dolibarr_documents/sellyoursaas/scripts/templates/
+---------------
+
+* If /home/jail/chroot/commonjail already exists (eg. you are only adding a new PHP version to an existing server), the tgz above will NOT be re-extracted onto it automatically - sync the freshly rebuilt template into the live jail so already-deployed instances see the change too, without removing anything already there:
+
+[source,bash]
+---------------
+rsync -a /home/jail/chroot/template/ /home/jail/chroot/commonjail/
 ---------------
 
 * Modify the /etc/sellyoursaas.conf file of your instances server
@@ -3240,8 +3256,10 @@ Then enable it by adding the symlinks into *`/etc/php/*.*/*/php.ini+`* (the one 
 [source,bash]
 ---------------
 cd /etc/php/8.1/cli/conf.d/; ln -fs /etc/php/sellyoursaas.ini; cd /etc/php/8.1/apache2/conf.d/; ln -fs /etc/php/sellyoursaas.ini;
-#cd /etc/php/8.1/fpm/conf.d/; ln -fs /etc/php/sellyoursaas.ini;
+cd /etc/php/8.1/fpm/conf.d/; ln -fs /etc/php/sellyoursaas.ini;
 ---------------
+
+NOTE: for a PHP-FPM server, `scripts/deployment_setup_phpfpm.sh` already creates this `fpm/conf.d` symlink (and reloads php-fpm) for every version it sets up, so this manual step is only needed if `auto_prepend_file` / `sendmail_path` stop working and you need to check or redo it by hand.
 
 
 Create the files *phpmail.log* and *phpsendmail.log*:
@@ -3274,6 +3292,56 @@ cp -p /home/admin/wwwroot/dolibarr_documents/sellyoursaas/spam/blacklistcontent 
 chmod a+rwx /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/spam; chmod a+rw /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/spam/*;
 
 ---------------
+
+==== PHP-FPM per instance and HTTP/2 migration
+
+On **Deployment servers**, an instance can run under mod_php (default) or under its own PHP-FPM pool, one systemd service per instance (`sellyoursaas-php<version>-fpm-<fqn>.service`), letting different instances run different PHP versions on the same server. Set `phpfpm=1` and `phpversion=<default version>` in `/etc/sellyoursaas.conf` to make new deployments use PHP-FPM (with that default version, overridable per contract); existing mod_php instances are not affected until switched individually (contract PHP version field, or in bulk with `scripts/deployment_migrate_server_http2.sh`, see below).
+
+All three scripts below (`deployment_setup_phpfpm.sh`, `deployment_migrate_server_http2.sh`, `switch_instance_phpversion.sh`) connect back to the **master** database directly, using the same `databasehost=`/`databaseport=`/`databaseuser=`/`databasepass=`/`database=` credentials as `/etc/sellyoursaas.conf` already carries for other scripts (eg. `batch_customers.php`), and the table prefix read from `dolibarr_main_db_prefix` in the local Dolibarr's `conf.php` (`dolibarrdir=`), falling back to `llx_` like Dolibarr itself does if that is not set. They refuse to run at all if that prefix does not actually resolve to a real table on the master, or if `SELLYOURSAAS_ENABLE_PHPVERSION_OVERRIDE` is not enabled there (see step 1 below) - **enable that setting before running any of them**.
+
+===== Step 1: enable the feature on the master
+
+On the **Master server**, *Home - Setup - Other*, set `SELLYOURSAAS_ENABLE_PHPVERSION_OVERRIDE = 1`. While disabled (the default), none of the *Deployment server* or contract fields described below exist on screen - it is not just that they are left empty - and none of the three scripts in this section will run.
+
+NOTE: the *Home - Setup - Other* toggle, the *Deployment server* fields (*PhpVersionsAvailable*/*PhpVersionDefault*/*AllowPhpVersionOverride*) and the contract *PhpVersion* dropdown described under "Contract-side configuration" below ship in a companion module update, proposed as a separate PR from the scripts documented here. In the meantime the underlying constant can be set directly (`UPDATE llx_const SET value='1' WHERE name='SELLYOURSAAS_ENABLE_PHPVERSION_OVERRIDE' AND entity=1`, or inserted if the row does not exist yet) to use the scripts standalone.
+
+===== Step 2: prepare the server for PHP-FPM
+
+If the server is still on an Ubuntu release too old for Sury's PPA (`deployment_setup_phpfpm.sh` checks this and refuses to run otherwise - see https://packages.sury.org/php/dists/ for the current list, eg. Ubuntu 20.04 "focal" was dropped), the OS itself needs upgrading first. This is a manual, supervised procedure, not something to automate unattended on a server carrying live instances:
+
+. Stop Apache (`systemctl stop apache2`) - every instance on the server goes down for the duration.
+. Bring the system fully up to date first: `do-release-upgrade` refuses to start otherwise (prints "Please install all available updates for your release before upgrading" and exits, without actually erroring out). Run `apt-get update && apt-get upgrade -y && apt-get dist-upgrade -y && apt-get autoremove -y`.
+. Drop a `Dpkg::Options { "--force-confdef"; "--force-confold"; }` snippet into `/etc/apt/apt.conf.d/` so config-file-conflict prompts default to keeping the existing file instead of hanging waiting for input, then run `DEBIAN_FRONTEND=noninteractive do-release-upgrade -m server -f DistUpgradeViewNonInteractive`. It still needs supervising (watch the log for anything unexpected) even in this frontend - it is not safe to fire-and-forget.
+. Once it finishes, check `/var/run/reboot-required` and reboot deliberately (not automatically) - the point where the server briefly drops off the network entirely.
+. If the old PHP version's Apache module (mod_php) got fully purged by the OS upgrade (it usually does, since the new release's repositories no longer carry the old PHP branch), every vhost's `php_admin_value open_basedir` line - the same one `scripts/deployment_migrate_server_http2.sh` neutralizes later in the normal flow - is now invalid and breaks `apache2ctl configtest` immediately, before `deployment_setup_phpfpm.sh` even gets to enabling `mod_proxy_fcgi`. Comment those lines out (`sed -i 's/^\([[:space:]]*\)php_admin_value open_basedir/\1#php_admin_value open_basedir/'` across every vhost) *before* running `deployment_setup_phpfpm.sh` below, not after.
+. Existing instances were running under whatever single mod_php version was active before the upgrade - request that version explicitly in `deployment_setup_phpfpm.sh`'s version list alongside the new default, and switch each instance to it individually (`switch_instance_phpversion.sh`), rather than letting `scripts/deployment_migrate_server_http2.sh` bulk-switch every still-mod_php vhost to the new server default - existing instances keep the PHP version they were actually running, same policy as everywhere else in this section.
+
+`scripts/deployment_setup_phpfpm.sh <default_version> <version> [version...]` does everything a server needs *before* any instance can be switched or `scripts/deployment_migrate_server_http2.sh` can run. Example, to install PHP 8.1 to 8.4 with 8.3 as the default:
+
+[source,bash]
+---------------
+scripts/deployment_setup_phpfpm.sh 8.3 8.1 8.2 8.3 8.4
+---------------
+
+It: checks the Sury PHP PPA (https://packages.sury.org/php/) actually supports the server's Ubuntu/Debian codename first (older releases like Ubuntu 20.04 "focal" have been dropped - upgrading the OS, eg. with `do-release-upgrade`, is the usual fix); adds that PPA; installs php-fpm and a standard extension set for every version listed (skipping any extension package not available for a given version instead of failing outright - eg. `php-rrd` is not packaged past PHP 8.1); masks the distro's own default `php<version>-fpm.service` for every non-default version and keeps the default version's enabled; creates `pool.d/sellyoursaas` under every version; deploys the AppArmor local override needed for a php-fpm pool socket (`/etc/apparmor.d/local/php-fpm`, auto-detecting the installed ImageMagick policy directory); sets `phpfpm=`/`phpversion=` in `/etc/sellyoursaas.conf`; enables `mod_proxy_fcgi` (with the Apache restart this needs, since `a2enmod` alone does not load a new module into the already-running process); and, only on a server actually using Jailkit for SellYourSaaS (`chrootdir=` set in `/etc/sellyoursaas.conf` and `jk_init.ini` already has its `[php]` section - see the Jailkit section above), refreshes the common jail *and every existing private jail* (an instance with the "SSH access type" contract field set to *PrivateUserJail* got its own full copy at deploy time under `$chrootdir/<osusername>`, instead of sharing the common one) so SSH/SFTP users get a `php<version>` CLI binary matching every version just installed, plus whichever version mod_php is still actively serving on this server (if any - existing instances keep using it until migrated). Skipped with a message otherwise (jailkit not installed, or installed but never set up for this module).
+
+Finally, it writes the result straight onto this server's **Deployment server** card on the master: *PhpVersionsAvailable* (the same detection the *DetectPhpVersions* button runs - `ls /usr/sbin/php-fpm*`), *PhpVersionDefault* (always overwritten with `<default_version>`, even if an admin had set something else there by hand), and *AllowPhpVersionOverride* (always turned on). No manual step is needed on the card after running this script; the button remains useful only to re-detect versions installed outside of it.
+
+It does not touch any existing vhost, and is idempotent (safe to re-run, eg. to add one more PHP version to a server later).
+
+===== Step 3: migrate existing mod_php instances, and HTTP/2
+
+Why HTTP/2 needs more than just installing php-fpm: `mod_http2` refuses to load under `mpm_prefork` (which `mpm_itk` is built on), so HTTP/2 requires `mpm_event`. But `mpm_event` has no per-vhost UID switching like `mpm_itk` does, so Apache then runs every vhost as a single shared user (`www-data`). PHP execution stays isolated per client either way (each php-fpm pool runs as its own OS user via `user=`/`group=` in its pool config), but `www-data` still needs read+traverse access to reach each instance's `htdocs/` and hand `.php` requests to the fcgi socket. `scripts/action_deploy_undeploy.sh` grants this via a POSIX ACL after every deploy, scoped to `htdocs/` only - `documents/` (private Dolibarr data) is never `Alias`ed into any vhost and stays fully unreadable by `www-data`, since it is only ever reached through an authenticated PHP script running under the instance's own pool user.
+
+Once the server is prepared (step 2), `scripts/deployment_migrate_server_http2.sh` does the rest of the one-time, per-server work: switches any still-mod_php instance to the server's default PHP-FPM version (via `scripts/switch_instance_phpversion.sh`, the same script the contract PHP version field calls for a single instance), then does a second pass over every vhost *already* on PHP-FPM (passing each its own current version, a no-op switch) purely so its contract's *PhpVersion* field gets synced too - needed for any instance that was already running PHP-FPM before this tooling existed, since it would otherwise never go through `switch_instance_phpversion.sh` and never get that field written. It then installs `acl` and applies/verifies the htdocs ACL above on every existing instance, and finally switches `mpm_itk`/`mpm_prefork` to `mpm_event` and enables `http2`. It is idempotent and safe to re-run. It refuses to run if `mod_proxy_fcgi` is not enabled, or if `phpfpm=`/`phpversion=` are not set (run step 2 first).
+
+`scripts/switch_instance_phpversion.sh` updates every vhost belonging to the instance, not just the main one: an instance can have extra custom-URL vhosts (one full `<VirtualHost>` per domain, since each needs its own SSL cert - see the *CustomURL* option), and every one of them proxies to the same php-fpm socket. Only one custom URL is ever known to Dolibarr (the contract's `custom_url` field, giving `<fqn>.custom.conf`); further ones added by hand (multi-URL support being deferred) are matched by filename glob (`<fqn>.custom2.conf`, `<fqn>.custom3.conf`...) and get the same treatment. After a successful switch - or after confirming every vhost is already on the target version - it writes that version back to the contract's *PhpVersion* field on the master, so that field always reflects what is actually running without needing a manual check.
+
+If the server needs several PHP versions to keep coexisting for a while (eg. some instances need an old version step 2 also installed, others should move to a newer default) that is fine under PHP-FPM, one pool per instance - but not under mod_php, which only ever runs one version at a time for every instance on the server. Migrate those instances to PHP-FPM individually first (keeping each one on its current PHP version) before running `scripts/deployment_migrate_server_http2.sh`, which needs every instance already off mod_php.
+
+===== Contract-side configuration
+
+On a **contract**, the extrafield *PhpVersion* only appears when both the module-wide feature (step 1) and that contract's deployment server's *AllowPhpVersionOverride* are on; its dropdown is restricted to that server's *PhpVersionsAvailable* the same way (`class/actions_sellyoursaas.class.php`, `contractcard` hook, mutates the extrafield definition in place before display - it does not touch what is stored, only what is offered on screen). Left on *UseServerDefault*, the instance follows whatever *PhpVersionDefault* says; changing it later (once already deployed) triggers `changephpversion`, which is what actually calls `scripts/switch_instance_phpversion.sh` on the deployment server - which, as described above, also keeps this same field in sync afterward.
 
 
 === Setup of logrotate

--- a/doc/Documentation SellYourSaas - Web portal - EN.asciidoc
+++ b/doc/Documentation SellYourSaas - Web portal - EN.asciidoc
@@ -1488,6 +1488,8 @@ Then enable it by adding the symlinks into *`/etc/php/*.*/*/php.ini+`* (the one 
 cd /etc/php/8.1/fpm/conf.d/; ln -fs /etc/php/sellyoursaas.ini;
 ---------------
 
+NOTE: this manual step stays the definitive setup here - `scripts/deployment_setup_phpfpm.sh` does not apply to this web portal server. That script is scoped to deployment servers hosting multiple Dolibarr instances (it checks the master database's per-instance PHP version override setting, configures mod_proxy_fcgi and refreshes jailkit jails), whereas this portal server runs a single fixed PHP version.
+
 
 === Setup of logrotate
 

--- a/etc/sellyoursaas.conf
+++ b/etc/sellyoursaas.conf
@@ -99,6 +99,10 @@ remotebackupdir=/mnt/diskbackup
 #templatesdir=/path/of/vhostfile/templates
 # Options to change the directory of the web app root (relative path)
 #htdocsdir=/htdocs
+# Options to change the directory where the sellyoursaas module/repository itself is
+# installed (open_basedir needs read access to its scripts/ subdirectory, eg. for
+# phpsendmail.php/phpsendmailprepend.php), if not the default /home/admin/wwwroot/dolibarr_sellyoursaas
+#sellyoursaasdir=/path/of/sellyoursaas
 
 # Options to change the SSL certificates names in Apache virtualhost
 #websslcertificatecrt=with.sellyoursaas.com.crt

--- a/scripts/action_customurl_instance.sh
+++ b/scripts/action_customurl_instance.sh
@@ -159,6 +159,14 @@ fi
 
 export CUSTOMDOMAIN=${46}
 
+# Per-instance PHP version override (from contract extrafield "phpversion"), takes priority
+# over the server-wide "phpversion=" read from /etc/sellyoursaas.conf when set. For mode
+# "changephpversion" this is the target version to switch to - switch_instance_phpversion.sh
+# discovers the instance's current pool(s) from disk itself, no need to pass it explicitly.
+export phpversionforinstance=${50//£/ }
+if [[ "x$phpversionforinstance" != "x" && "x$phpversionforinstance" != "x-" ]]; then
+	phpversion=$phpversionforinstance
+fi
 
 
 export ErrorLog='#ErrorLog'
@@ -265,6 +273,8 @@ if [[ "$mode" == "deploycustomurl" ]]; then
 				  sed -e 's;__SELLYOURSAAS_LOGIN_FOR_SUPPORT__;$SELLYOURSAAS_LOGIN_FOR_SUPPORT;g' | \
 				  sed -e 's;#ErrorLog;$ErrorLog;g' | \
 				  sed -e 's;__webMyAccount__;$SELLYOURSAAS_ACCOUNT_URL;g' | \
+				  sed -e 's;__phpversion__;$phpversion;g' | \
+				  sed -e 's;__fqn__;$fqn;g' | \
 				  sed -e 's;__webAppPath__;$instancedir;g' > $apacheconf"
 		cat $vhostfile | sed -e "s/__webAppDomain__/$customurl/g" | \
 				  sed -e "s/__webAppAliases__/$customurl/g" | \
@@ -282,6 +292,8 @@ if [[ "$mode" == "deploycustomurl" ]]; then
 				  sed -e "s;__SELLYOURSAAS_LOGIN_FOR_SUPPORT__;$SELLYOURSAAS_LOGIN_FOR_SUPPORT;g" | \
 				  sed -e "s;#ErrorLog;$ErrorLog;g" | \
 				  sed -e "s;__webMyAccount__;$SELLYOURSAAS_ACCOUNT_URL;g" | \
+				  sed -e "s;__phpversion__;$phpversion;g" | \
+				  sed -e "s;__fqn__;$fqn;g" | \
 				  sed -e "s;__webAppPath__;$instancedir;g" > $apacheconf
 	export vhostko=$?
 	echo `date +'%Y-%m-%d %H:%M:%S'`" Result of generation of file $apacheconf = $vhostko"
@@ -355,6 +367,20 @@ if [[ "$mode" == "deploycustomurl" ]]; then
 		exit 20
 	else
 		sleep 3
+	fi
+fi
+
+if [[ "$mode" == "changephpversion" ]]; then
+	if [[ "x$phpfpm" == "x" ]]; then
+		echo "This server is not configured for phpfpm (phpfpm= not set in /etc/sellyoursaas.conf), nothing to do for mode changephpversion"
+	else
+		echo "$scriptdir/switch_instance_phpversion.sh $fqn $osusername $instancedir $phpversion"
+		"$scriptdir/switch_instance_phpversion.sh" "$fqn" "$osusername" "$instancedir" "$phpversion"
+		if [[ "x$?" != "x0" ]]; then
+			echo "Failed to change PHP version for $fqn"
+			echo "Failed to change PHP version for $fqn, see the remote agent log for details" | mail -aFrom:$EMAILFROM -s "[Alert] Pb in change PHP version" $EMAILTO
+			exit 20
+		fi
 	fi
 fi
 

--- a/scripts/action_deploy_undeploy.sh
+++ b/scripts/action_deploy_undeploy.sh
@@ -39,6 +39,15 @@ templatesdir=`grep '^templatesdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
 phpfpm=`grep '^phpfpm=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
 phpversion=`grep '^phpversion=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
 localip=`grep '^localip=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
+
+# php-fpm/apache open_basedir needs read access to the sellyoursaas module's own scripts/
+# directory (eg. for phpsendmail.php/phpsendmailprepend.php) - possibility to change it if
+# the module was not installed into the default /home/admin/wwwroot/dolibarr_sellyoursaas
+sellyoursaasdir=`grep '^sellyoursaasdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
+if [[ "x$sellyoursaasdir" == "x" ]]; then
+  sellyoursaasdir="/home/admin/wwwroot/dolibarr_sellyoursaas"
+fi
+sellyoursaasscriptsdir="$sellyoursaasdir/scripts"
 if [[ "x$templatesdir" != "x" ]]; then
   if [[ "x$phpfpm" != "x" ]]; then
     export vhostfile="$templatesdir/vhostHttps-phpfpm-sellyoursaas.template"
@@ -180,6 +189,12 @@ fi
 export CUSTOMDOMAIN=${46}
 export cliafterdeployoption=${49}
 
+# Per-instance PHP version override (from contract extrafield "phpversion"), takes priority
+# over the server-wide "phpversion=" read from /etc/sellyoursaas.conf when set.
+export phpversionforinstance=${50//£/ }
+if [[ "x$phpversionforinstance" != "x" && "x$phpversionforinstance" != "x-" ]]; then
+	phpversion=$phpversionforinstance
+fi
 
 
 export ErrorLog='#ErrorLog'
@@ -439,8 +454,8 @@ if [[ "$mode" == "deployall" ]]; then
 									echo "mv $chrootdir/$privatejailtemplatename $chrootdir/$osusername"
 									mv $chrootdir/$privatejailtemplatename $chrootdir/$osusername
 								else
-									echo "jk_init -c /etc/jailkit/jk_init.ini $chrootdir/$osusername extendedshell limitedshell groups sftp rsync editors git php mysqlclient"
-									jk_init -c /etc/jailkit/jk_init.ini $chrootdir/$osusername extendedshell limitedshell groups sftp rsync editors git php mysqlclient >/dev/null 2>&1
+									echo "jk_init -c /etc/jailkit/jk_init.ini $chrootdir/$osusername extendedshell limitedshell groups sftp rsync editors git php mysqlclient acl"
+									jk_init -c /etc/jailkit/jk_init.ini $chrootdir/$osusername extendedshell limitedshell groups sftp rsync editors git php mysqlclient acl >/dev/null 2>&1
 								fi
 							fi
 							echo "mkdir -p $chrootdir/$osusername$targetdir/$osusername"
@@ -477,6 +492,19 @@ if [[ "$mode" == "undeploy" || "$mode" == "undeployall" ]]; then
 	rm -f $targetdir/$osusername/$dbname/*.log >/dev/null 2>&1
 	echo rm -f $targetdir/$osusername/$dbname/*.log.*
 	rm -f $targetdir/$osusername/$dbname/*.log.* >/dev/null 2>&1
+
+	# Stop this instance's php-fpm service(s) FIRST, before the jailkit/killall/usermod cleanup
+	# below: the pool service has Restart=always (see poolservice-phpfpm.template), so leaving it
+	# running just has systemd respawn a worker as $osusername within RestartSec, making the
+	# usermod further down fail ("user ... is currently used by process ...") and leave the passwd
+	# home field pointing at the jail directory this same block is about to delete. Match any PHP
+	# version, not just the server's default $phpversion further below: an instance's actual
+	# running version can differ from it via changephpversion.
+	for svc in $(ls /etc/systemd/system/sellyoursaas-php*-fpm-"$fqn".service 2>/dev/null); do
+		svcname=$(basename "$svc")
+		echo "Stop php-fpm service $svcname before jailkit/user cleanup"
+		systemctl disable --now "$svcname" 2>/dev/null
+	done
 
 	if [[ "$sshaccesstype" > "0" ]]; then
 
@@ -1170,7 +1198,8 @@ if [[ "$mode" == "deploy" || "$mode" == "deployall" ]]; then
 				sed -e 's;__fqn__;$fqn;g' | \
 				sed -e 's;__instancename__;$instancename;g' | \
 				sed -e 's;__localip__;$localip;g' | \
-			  sed -e 's;__webAppPath__;$instancedir;g' > $apacheconf"
+			  sed -e 's;__webAppPath__;$instancedir;g' | \
+			  sed -e 's;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g' > $apacheconf"
 	cat $vhostfile | sed -e "s/__webAppDomain__/$instancename.$domainname/g" | \
 			  sed -e "s/__webAppAliases__/$instancename.$domainname/g" | \
 			  sed -e "s/__webAppLogName__/$instancename/g" | \
@@ -1191,7 +1220,8 @@ if [[ "$mode" == "deploy" || "$mode" == "deployall" ]]; then
 				sed -e "s;__fqn__;$fqn;g" | \
 				sed -e "s;__instancename__;$instancename;g" | \
 				sed -e "s;__localip__;$localip;g" | \
-			  sed -e "s;__webAppPath__;$instancedir;g" > $apacheconf
+			  sed -e "s;__webAppPath__;$instancedir;g" | \
+			  sed -e "s;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g" > $apacheconf
 
 
 	# Enable conf with ln
@@ -1330,6 +1360,7 @@ if [[ "$mode" == "deploy" || "$mode" == "deployall" ]]; then
 				  sed -e 's;#ErrorLog;$ErrorLog;g' | \
 				  sed -e 's;__webMyAccount__;$SELLYOURSAAS_ACCOUNT_URL;g' | \
 				  sed -e 's;__webAppPath__;$instancedir;g' | \
+				  sed -e 's;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g' | \
 				  sed -e 's;__phpversion__;$phpversion;g' | \
 				  sed -e 's;__fqn__;$fqn;g' | \
 				  sed -e 's;__instancename__;$instancename;g' | \
@@ -1352,6 +1383,7 @@ if [[ "$mode" == "deploy" || "$mode" == "deployall" ]]; then
 				  sed -e "s;#ErrorLog;$ErrorLog;g" | \
 				  sed -e "s;__webMyAccount__;$SELLYOURSAAS_ACCOUNT_URL;g" | \
 				  sed -e "s;__webAppPath__;$instancedir;g" | \
+				  sed -e "s;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g" | \
 				  sed -e "s;__phpversion__;$phpversion;g" | \
 				  sed -e "s;__fqn__;$fqn;g" | \
 				  sed -e "s;__instancename__;$instancename;g" | \
@@ -1397,7 +1429,8 @@ if [[ "$mode" == "deploy" || "$mode" == "deployall" ]]; then
 				  sed -e 's;__fqn__;$fqn;g' | \
 				  sed -e 's;__instancename__;$instancename;g' | \
 				  sed -e 's;__localip__;$localip;g' | \
-				  sed -e 's;__webAppPath__;$instancedir;g' > $phpfpmconf"
+				  sed -e 's;__webAppPath__;$instancedir;g' | \
+				  sed -e 's;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g' > $phpfpmconf"
 		cat $fpmpoolfiletemplate | sed -e "s/__webAppDomain__/$instancename.$domainname/g" | \
 				  sed -e "s/__webAppAliases__/$instancename.$domainname/g" | \
 				  sed -e "s/__webAppLogName__/$instancename/g" | \
@@ -1418,7 +1451,8 @@ if [[ "$mode" == "deploy" || "$mode" == "deployall" ]]; then
 				  sed -e "s;__fqn__;$fqn;g" | \
 				  sed -e "s;__instancename__;$instancename;g" | \
 				  sed -e "s;__localip__;$localip;g" | \
-				  sed -e "s;__webAppPath__;$instancedir;g" > $phpfpmconf
+				  sed -e "s;__webAppPath__;$instancedir;g" | \
+				  sed -e "s;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g" > $phpfpmconf
 
 		echo `date +'%Y-%m-%d %H:%M:%S'`" ***** Create php fpm service $phpfpmservice from $fpmservicefiletemplate"
 		if [[ -s $phpfpmservice ]]
@@ -1557,6 +1591,24 @@ if [[ "$mode" == "undeploy" || "$mode" == "undeployall" ]]; then
 		fi
 	else
 		echo "Virtual host $apacheconf seems already disabled"
+	fi
+
+	if [[ "x$phpfpm" != "x" ]]; then
+		# The service(s) were already stopped/disabled earlier in this script (before the
+		# jailkit/user cleanup); remove the now-unused unit and pool conf files here so they
+		# don't pile up on disk for every undeployed instance. Match any PHP version, not just
+		# $phpversion: the instance's actual version can differ from it via changephpversion.
+		for phpfpmsvc in $(ls /etc/systemd/system/sellyoursaas-php*-fpm-"$fqn".service 2>/dev/null); do
+			echo "Remove php-fpm service file $phpfpmsvc"
+			rm -f "$phpfpmsvc"
+		done
+		for phpfpmpoolconf in /etc/php/*/fpm/pool.d/sellyoursaas/$fqn.phpfpm.conf; do
+			if [ -f "$phpfpmpoolconf" ]; then
+				echo "Remove php-fpm pool conf $phpfpmpoolconf"
+				rm -f "$phpfpmpoolconf"
+			fi
+		done
+		systemctl daemon-reload
 	fi
 fi
 

--- a/scripts/action_suspend_unsuspend.sh
+++ b/scripts/action_suspend_unsuspend.sh
@@ -34,6 +34,15 @@ htdocsdir=`grep '^htdocsdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
 phpfpm=`grep '^phpfpm=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
 phpversion=`grep '^phpversion=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
 localip=`grep '^localip=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
+
+# php-fpm/apache open_basedir needs read access to the sellyoursaas module's own scripts/
+# directory (eg. for phpsendmail.php/phpsendmailprepend.php) - possibility to change it if
+# the module was not installed into the default /home/admin/wwwroot/dolibarr_sellyoursaas
+sellyoursaasdir=`grep '^sellyoursaasdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
+if [[ "x$sellyoursaasdir" == "x" ]]; then
+  sellyoursaasdir="/home/admin/wwwroot/dolibarr_sellyoursaas"
+fi
+sellyoursaasscriptsdir="$sellyoursaasdir/scripts"
 if [[ "x$htdocsdir" == "x" ]]; then
 	export htdocsdir="/htdocs"
 fi
@@ -168,6 +177,12 @@ fi
 
 export CUSTOMDOMAIN=${46}
 
+# Per-instance PHP version override (from contract extrafield "phpversion"), takes priority
+# over the server-wide "phpversion=" read from /etc/sellyoursaas.conf when set.
+export phpversionforinstance=${50//£/ }
+if [[ "x$phpversionforinstance" != "x" && "x$phpversionforinstance" != "x-" ]]; then
+	phpversion=$phpversionforinstance
+fi
 
 
 export ErrorLog='#ErrorLog'
@@ -308,7 +323,8 @@ if [[ "$mode" == "rename" ]]; then
 				sed -e 's;__fqn__;$fqn;g' | \
 				sed -e 's;__instancename__;$instancename;g' | \
 				sed -e 's;__localip__;$localip;g' | \
-		  sed -e 's;__webAppPath__;$instancedir;g' > $apacheconf"
+		  sed -e 's;__webAppPath__;$instancedir;g' | \
+		  sed -e 's;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g' > $apacheconf"
 	cat $vhostfile | sed -e "s/__webAppDomain__/$instancename.$domainname/g" | \
 			  sed -e "s/__webAppAliases__/$instancename.$domainname/g" | \
 			  sed -e "s/__webAppLogName__/$instancename/g" | \
@@ -329,7 +345,8 @@ if [[ "$mode" == "rename" ]]; then
 				sed -e "s;__fqn__;$fqn;g" | \
 				sed -e "s;__instancename__;$instancename;g" | \
 				sed -e "s;__localip__;$localip;g" | \
-			  sed -e "s;__webAppPath__;$instancedir;g" > $apacheconf
+			  sed -e "s;__webAppPath__;$instancedir;g" | \
+			  sed -e "s;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g" > $apacheconf
 
 
 	#echo Enable conf with a2ensite $fqn.conf
@@ -450,6 +467,7 @@ if [[ "$mode" == "rename" ]]; then
 						  sed -e 's;#ErrorLog;$ErrorLog;g' | \
 						  sed -e 's;__webMyAccount__;$SELLYOURSAAS_ACCOUNT_URL;g' | \
 						  sed -e 's;__webAppPath__;$instancedir;g' | \
+						  sed -e 's;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g' | \
 						  sed -e 's;__phpversion__;$phpversion;g' | \
 						  sed -e 's;__fqn__;$fqn;g' | \
 						  sed -e 's;__instancename__;$instancename;g' | \
@@ -480,6 +498,7 @@ if [[ "$mode" == "rename" ]]; then
 						  sed -e "s;__instancename__;$instancename;g" | \
 						  sed -e "s;__localip__;$localip;g" | \
 						  sed -e "s;__webAppPath__;$instancedir;g" | \
+						  sed -e "s;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g" | \
 						  sed -e "s/with\.sellyoursaas\.com/$CERTIFFORCUSTOMDOMAIN/g" > $apacheconf
 			
 			
@@ -595,6 +614,7 @@ if [[ "$mode" == "rename" ]]; then
 				  sed -e 's;#ErrorLog;$ErrorLog;g' | \
 				  sed -e 's;__webMyAccount__;$SELLYOURSAAS_ACCOUNT_URL;g' | \
 				  sed -e 's;__webAppPath__;$instancedir;g' | \
+				  sed -e 's;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g' | \
 				  sed -e 's;__phpversion__;$phpversion;g' | \
 				  sed -e 's;__fqn__;$fqn;g' | \
 				  sed -e 's;__instancename__;$instancename;g' | \
@@ -625,6 +645,7 @@ if [[ "$mode" == "rename" ]]; then
 				  sed -e "s;__instancename__;$instancename;g" | \
 				  sed -e "s;__localip__;$localip;g" | \
 				  sed -e "s;__webAppPath__;$instancedir;g" | \
+				  sed -e "s;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g" | \
 				  sed -e "s/with\.sellyoursaas\.com/$CERTIFFORCUSTOMDOMAIN/g" > $apacheconf
 	
 	
@@ -752,7 +773,8 @@ if [[ "$mode" == "suspend" || $mode == "suspendmaintenance" || $mode == "suspend
         sed -e 's;__fqn__;$fqn;g' | \
         sed -e 's;__instancename__;$instancename;g' | \
         sed -e 's;__localip__;$localip;g' | \
-			  sed -e 's;__webAppPath__;$instancedir;g' > $apacheconf"
+			  sed -e 's;__webAppPath__;$instancedir;g' | \
+			  sed -e 's;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g' > $apacheconf"
 	cat $vhostfiletouse | sed -e "s/__webAppDomain__/$instancename.$domainname/g" | \
 			  sed -e "s/__webAppAliases__/$instancename.$domainname/g" | \
 			  sed -e "s/__webAppLogName__/$instancename/g" | \
@@ -773,7 +795,8 @@ if [[ "$mode" == "suspend" || $mode == "suspendmaintenance" || $mode == "suspend
         sed -e "s;__fqn__;$fqn;g" | \
         sed -e "s;__instancename__;$instancename;g" | \
         sed -e "s;__localip__;$localip;g" | \
-			  sed -e "s;__webAppPath__;$instancedir;g" > $apacheconf
+			  sed -e "s;__webAppPath__;$instancedir;g" | \
+			  sed -e "s;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g" > $apacheconf
 
 
 	# Enable conf with ln
@@ -890,6 +913,7 @@ if [[ "$mode" == "suspend" || $mode == "suspendmaintenance" || $mode == "suspend
 				  sed -e 's;__instancename__;$instancename;g' | \
 				  sed -e 's;__localip__;$localip;g' | \
 				  sed -e 's;__webAppPath__;$instancedir;g' | \
+				  sed -e 's;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g' | \
 				  sed -e 's/with\.sellyoursaas\.com/$CERTIFFORCUSTOMDOMAIN/g' > $apacheconf"
 		cat $vhostfiletouse | sed -e "s/__webAppDomain__/$customurl/g" | \
 				  sed -e "s/__webAppAliases__/$customurl/g" | \
@@ -911,6 +935,7 @@ if [[ "$mode" == "suspend" || $mode == "suspendmaintenance" || $mode == "suspend
 				  sed -e "s;__instancename__;$instancename;g" | \
 				  sed -e "s;__localip__;$localip;g" | \
 				  sed -e "s;__webAppPath__;$instancedir;g" | \
+				  sed -e "s;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g" | \
 				  sed -e "s/with\.sellyoursaas\.com/$CERTIFFORCUSTOMDOMAIN/g" > $apacheconf
 
 
@@ -996,7 +1021,8 @@ if [[ "$mode" == "unsuspend" ]]; then
 				  sed -e 's;__fqn__;$fqn;g' | \
 				  sed -e 's;__instancename__;$instancename;g' | \
 				  sed -e 's;__localip__;$localip;g' | \
-			  sed -e 's;__webAppPath__;$instancedir;g' > $apacheconf"
+			  sed -e 's;__webAppPath__;$instancedir;g' | \
+			  sed -e 's;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g' > $apacheconf"
 	cat $vhostfiletouse | sed -e "s/__webAppDomain__/$instancename.$domainname/g" | \
 			  sed -e "s/__webAppAliases__/$instancename.$domainname/g" | \
 			  sed -e "s/__webAppLogName__/$instancename/g" | \
@@ -1015,7 +1041,8 @@ if [[ "$mode" == "unsuspend" ]]; then
 				  sed -e "s;__fqn__;$fqn;g" | \
 				  sed -e "s;__instancename__;$instancename;g" | \
 				  sed -e "s;__localip__;$localip;g" | \
-			  sed -e "s;__webAppPath__;$instancedir;g" > $apacheconf
+			  sed -e "s;__webAppPath__;$instancedir;g" | \
+			  sed -e "s;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g" > $apacheconf
 
 
 	# Enable conf with ln
@@ -1129,6 +1156,7 @@ if [[ "$mode" == "unsuspend" ]]; then
 				  sed -e 's;__instancename__;$instancename;g' | \
 				  sed -e 's;__localip__;$localip;g' | \
 				  sed -e 's;__webAppPath__;$instancedir;g' | \
+				  sed -e 's;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g' | \
 				  sed -e 's/with\.sellyoursaas\.com/$CERTIFFORCUSTOMDOMAIN/g' > $apacheconf"
 		cat $vhostfiletouse | sed -e "s/__webAppDomain__/$customurl/g" | \
 				  sed -e "s/__webAppAliases__/$customurl/g" | \
@@ -1149,6 +1177,7 @@ if [[ "$mode" == "unsuspend" ]]; then
 				  sed -e "s;__instancename__;$instancename;g" | \
 				  sed -e "s;__localip__;$localip;g" | \
 				  sed -e "s;__webAppPath__;$instancedir;g" | \
+				  sed -e "s;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g" | \
 				  sed -e "s/with\.sellyoursaas\.com/$CERTIFFORCUSTOMDOMAIN/g" > $apacheconf
 	
 	
@@ -1253,9 +1282,9 @@ if [[ "$mode" == "suspendredirect" ]]; then
 
 	echo `date +'%Y-%m-%d %H:%M:%S'`" ***** If IP for $instancename in DNS files /etc/bind/${ZONE} has changed and is not $REMOTEIP, we must also change the DNS entry."
 
-	echo "Entry $instancename not found into host /etc/bind/${ZONE}, we must add it with: /home/admin/wwwroot/dolibarr/scripts/deployment_update_dnszone.php set ${ZONE} $instancename $REMOTEIP"
+	echo "Entry $instancename not found into host /etc/bind/${ZONE}, we must add it with: $scriptdir/deployment_update_dnszone.php set ${ZONE} $instancename $REMOTEIP"
 
-	/home/admin/wwwroot/dolibarr_sellyoursaas/scripts/deployment_update_dnszone.php set "$domainname" "$instancename" "$REMOTEIP"
+	$scriptdir/deployment_update_dnszone.php set "$domainname" "$instancename" "$REMOTEIP"
 
 	if [[ "$?x" != "0x" ]]; then
 		echo error: Failed to update the DNS file.

--- a/scripts/action_website_instance.sh
+++ b/scripts/action_website_instance.sh
@@ -196,6 +196,8 @@ if [[ "x$olddoldataroot" != "x" && "x$newdoldataroot" != "x" ]]; then
 	cliafter=${cliafter/$olddoldataroot/$newdoldataroot}
 fi
 
+export pathforcertiflocal="${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt"
+
 # For debug
 echo `date +'%Y-%m-%d %H:%M:%S'`" input params for $0:"
 echo "mode = $mode"
@@ -269,7 +271,8 @@ if [[ "$mode" == "deploywebsite" ]]; then
 			  sed -e 's;__phpversion__;$phpversion;g' | \
 			  sed -e 's;__fqn__;$fqn;g' | \
 			  sed -e 's;__webAppPath__;$instancedir;g' | \
-			  sed -e 's;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g' > $apacheconf"
+			  sed -e 's;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g' | \
+			  sed -e 's;__sellyoursaasLocalCrtPath__;$pathforcertiflocal;g' > $apacheconf"
 	cat $vhostfilewebsite | sed -e "s/__webSiteDomain__/$CUSTOMDOMAIN/g" | \
 			  sed -e "s/__webSiteAliases__/$CUSTOMDOMAIN www.$CUSTOMDOMAIN/g" | \
 			  sed -e "s/__webSiteNamePath__/$WEBSITENAME/g" | \
@@ -292,7 +295,8 @@ if [[ "$mode" == "deploywebsite" ]]; then
 			  sed -e "s;__phpversion__;$phpversion;g" | \
 			  sed -e "s;__fqn__;$fqn;g" | \
 			  sed -e "s;__webAppPath__;$instancedir;g" | \
-			  sed -e "s;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g" > $apacheconf
+			  sed -e "s;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g" | \
+			  sed -e "s;__sellyoursaasLocalCrtPath__;$pathforcertiflocal;g" > $apacheconf
 	export vhostko=$?
 
 	echo `date +'%Y-%m-%d %H:%M:%S'`" Result of generation of file $apacheconf = $vhostko"
@@ -315,8 +319,8 @@ if [[ "$mode" == "deploywebsite" ]]; then
 	fi
 
 
-	echo "Create cert directory with mkdir /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/; chown admin:admin /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/;"
-	mkdir /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/; chown admin:admin /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/;
+	echo "Create cert directory with mkdir -p $pathforcertiflocal/; chown admin:admin $pathforcertiflocal/;"
+	mkdir -p $pathforcertiflocal/; chown admin:admin $pathforcertiflocal/;
 
 	if [[ ${46} == www.* ]]; then
 		echo certbot certonly -n -v --webroot -w $instancedir/documents/website/$WEBSITENAME -d www.$CUSTOMDOMAIN
@@ -332,13 +336,13 @@ if [[ "$mode" == "deploywebsite" ]]; then
 
 
 	echo "Link certificate for virtualhost with
-		ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/privkey.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$instancename.$domainname-$CUSTOMDOMAIN.key
-		ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/cert.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$instancename.$domainname-$CUSTOMDOMAIN.crt
-		ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/fullchain.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$instancename.$domainname-$CUSTOMDOMAIN-intermediate.crt
+		ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/privkey.pem $pathforcertiflocal/$instancename.$domainname-$CUSTOMDOMAIN.key
+		ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/cert.pem $pathforcertiflocal/$instancename.$domainname-$CUSTOMDOMAIN.crt
+		ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/fullchain.pem $pathforcertiflocal/$instancename.$domainname-$CUSTOMDOMAIN-intermediate.crt
 	"
-	ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/privkey.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$instancename.$domainname-$CUSTOMDOMAIN.key
-	ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/cert.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$instancename.$domainname-$CUSTOMDOMAIN.crt
-	ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/fullchain.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$instancename.$domainname-$CUSTOMDOMAIN-intermediate.crt
+	ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/privkey.pem $pathforcertiflocal/$instancename.$domainname-$CUSTOMDOMAIN.key
+	ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/cert.pem $pathforcertiflocal/$instancename.$domainname-$CUSTOMDOMAIN.crt
+	ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/fullchain.pem $pathforcertiflocal/$instancename.$domainname-$CUSTOMDOMAIN-intermediate.crt
 
 
 	echo `date +'%Y-%m-%d %H:%M:%S'`" Restart apache to have the new certificate being loaded"

--- a/scripts/action_website_instance.sh
+++ b/scripts/action_website_instance.sh
@@ -29,16 +29,35 @@ export scriptdir=$(dirname $(realpath ${0}))
 
 # possibility to change the directory of vhostfile templates
 templatesdir=`grep '^templatesdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
+
+# php-fpm/apache open_basedir needs read access to the sellyoursaas module's own scripts/
+# directory (eg. for phpsendmail.php/phpsendmailprepend.php) - possibility to change it if
+# the module was not installed into the default /home/admin/wwwroot/dolibarr_sellyoursaas
+sellyoursaasdir=`grep '^sellyoursaasdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
+if [[ "x$sellyoursaasdir" == "x" ]]; then
+  sellyoursaasdir="/home/admin/wwwroot/dolibarr_sellyoursaas"
+fi
+sellyoursaasscriptsdir="$sellyoursaasdir/scripts"
+phpfpm=`grep '^phpfpm=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
+phpversion=`grep '^phpversion=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
 if [[ "x$templatesdir" != "x" ]]; then
 	export vhostfile="$templatesdir/vhostHttps-sellyoursaas.template"
 	export vhostfilesuspended="$templatesdir/vhostHttps-sellyoursaas-suspended.template"
 	export vhostfilemaintenance="$templatesdir/vhostHttps-sellyoursaas-maintenance.template"
-	export vhostfilewebsite="$templatesdir/vhostHttps-sellyoursaas-dolibarrwebsite.template"
+	if [[ "x$phpfpm" != "x" ]]; then
+		export vhostfilewebsite="$templatesdir/vhostHttps-phpfpm-sellyoursaas-dolibarrwebsite.template"
+	else
+		export vhostfilewebsite="$templatesdir/vhostHttps-sellyoursaas-dolibarrwebsite.template"
+	fi
 else
 	export vhostfile="$scriptdir/templates/vhostHttps-sellyoursaas.template"
 	export vhostfilesuspended="$scriptdir/templates/vhostHttps-sellyoursaas-suspended.template"
 	export vhostfilemaintenance="$scriptdir/templates/vhostHttps-sellyoursaas-maintenance.template"
-	export vhostfilewebsite="$scriptdir/templates/vhostHttps-sellyoursaas-dolibarrwebsite.template"
+	if [[ "x$phpfpm" != "x" ]]; then
+		export vhostfilewebsite="$scriptdir/templates/vhostHttps-phpfpm-sellyoursaas-dolibarrwebsite.template"
+	else
+		export vhostfilewebsite="$scriptdir/templates/vhostHttps-sellyoursaas-dolibarrwebsite.template"
+	fi
 fi
 
 if [ "$(id -u)" != "0" ]; then
@@ -136,6 +155,12 @@ export CUSTOMDOMAIN=${46/www./}
 # The website name in document dir
 export WEBSITENAME=${47}
 
+# Per-instance PHP version override (from contract extrafield "phpversion"), takes priority
+# over the server-wide "phpversion=" read from /etc/sellyoursaas.conf when set.
+export phpversionforinstance=${50//£/ }
+if [[ "x$phpversionforinstance" != "x" && "x$phpversionforinstance" != "x-" ]]; then
+	phpversion=$phpversionforinstance
+fi
 
 
 export ErrorLog='#ErrorLog'
@@ -241,7 +266,10 @@ if [[ "$mode" == "deploywebsite" ]]; then
 			  sed -e 's;__SELLYOURSAAS_LOGIN_FOR_SUPPORT__;$SELLYOURSAAS_LOGIN_FOR_SUPPORT;g' | \
 			  sed -e 's;#ErrorLog;$ErrorLog;g' | \
 			  sed -e 's;__webMyAccount__;$SELLYOURSAAS_ACCOUNT_URL;g' | \
-			  sed -e 's;__webAppPath__;$instancedir;g' > $apacheconf"
+			  sed -e 's;__phpversion__;$phpversion;g' | \
+			  sed -e 's;__fqn__;$fqn;g' | \
+			  sed -e 's;__webAppPath__;$instancedir;g' | \
+			  sed -e 's;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g' > $apacheconf"
 	cat $vhostfilewebsite | sed -e "s/__webSiteDomain__/$CUSTOMDOMAIN/g" | \
 			  sed -e "s/__webSiteAliases__/$CUSTOMDOMAIN www.$CUSTOMDOMAIN/g" | \
 			  sed -e "s/__webSiteNamePath__/$WEBSITENAME/g" | \
@@ -261,7 +289,10 @@ if [[ "$mode" == "deploywebsite" ]]; then
 			  sed -e "s;__SELLYOURSAAS_LOGIN_FOR_SUPPORT__;$SELLYOURSAAS_LOGIN_FOR_SUPPORT;g" | \
 			  sed -e "s;#ErrorLog;$ErrorLog;g" | \
 			  sed -e "s;__webMyAccount__;$SELLYOURSAAS_ACCOUNT_URL;g" | \
-			  sed -e "s;__webAppPath__;$instancedir;g" > $apacheconf
+			  sed -e "s;__phpversion__;$phpversion;g" | \
+			  sed -e "s;__fqn__;$fqn;g" | \
+			  sed -e "s;__webAppPath__;$instancedir;g" | \
+			  sed -e "s;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g" > $apacheconf
 	export vhostko=$?
 
 	echo `date +'%Y-%m-%d %H:%M:%S'`" Result of generation of file $apacheconf = $vhostko"

--- a/scripts/ansible/launch_apt_upgrade.yml
+++ b/scripts/ansible/launch_apt_upgrade.yml
@@ -12,8 +12,18 @@
   become_method: sudo
   become_user: root
   tasks:
+  - name: Read sellyoursaasdir from /etc/sellyoursaas.conf
+    shell: "grep '^sellyoursaasdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2"
+    register: sellyoursaasdir_result
+    changed_when: false
+    failed_when: false
+
+  - name: Fall back to the documented default sellyoursaasdir if not set in /etc/sellyoursaas.conf
+    set_fact:
+      sellyoursaasdir: "{{ sellyoursaasdir_result.stdout if sellyoursaasdir_result.stdout != '' else '/home/admin/wwwroot/dolibarr_sellyoursaas' }}"
+
   - name: Switch instances in maintenance mode
-    command: /home/admin/wwwroot/dolibarr_sellyoursaas/scripts/deployment_make_instances_offlineonline.sh maintenance.php offline
+    command: "{{ sellyoursaasdir }}/scripts/deployment_make_instances_offlineonline.sh maintenance.php offline"
     register: command_output
 
   - debug:
@@ -35,7 +45,7 @@
       var: command_output.stdout_lines
 
   - name: Restore the production mode
-    command: /home/admin/wwwroot/dolibarr_sellyoursaas/scripts/deployment_make_instances_offlineonline.sh maintenance.php online
+    command: "{{ sellyoursaasdir }}/scripts/deployment_make_instances_offlineonline.sh maintenance.php online"
     register: command_output
 
   - debug:

--- a/scripts/ansible/launch_clean.yml
+++ b/scripts/ansible/launch_clean.yml
@@ -12,8 +12,18 @@
   become_method: sudo
   become_user: root
   tasks:
+  - name: Read sellyoursaasdir from /etc/sellyoursaas.conf
+    shell: "grep '^sellyoursaasdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2"
+    register: sellyoursaasdir_result
+    changed_when: false
+    failed_when: false
+
+  - name: Fall back to the documented default sellyoursaasdir if not set in /etc/sellyoursaas.conf
+    set_fact:
+      sellyoursaasdir: "{{ sellyoursaasdir_result.stdout if sellyoursaasdir_result.stdout != '' else '/home/admin/wwwroot/dolibarr_sellyoursaas' }}"
+
   - name: Launch clean.sh
-    command: "/home/admin/wwwroot/dolibarr_sellyoursaas/scripts/clean.sh {{command}}"
+    command: "{{ sellyoursaasdir }}/scripts/clean.sh {{command}}"
     register: command_output
 
   - debug:

--- a/scripts/ansible/launch_deployment_deploy_module.yml
+++ b/scripts/ansible/launch_deployment_deploy_module.yml
@@ -11,8 +11,18 @@
   become_method: sudo
   become_user: root
   tasks:
+  - name: Read sellyoursaasdir from /etc/sellyoursaas.conf
+    shell: "grep '^sellyoursaasdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2"
+    register: sellyoursaasdir_result
+    changed_when: false
+    failed_when: false
+
+  - name: Fall back to the documented default sellyoursaasdir if not set in /etc/sellyoursaas.conf
+    set_fact:
+      sellyoursaasdir: "{{ sellyoursaasdir_result.stdout if sellyoursaasdir_result.stdout != '' else '/home/admin/wwwroot/dolibarr_sellyoursaas' }}"
+
   - name: Launch deployment_deploy_module.php
-    command: /home/admin/wwwroot/dolibarr_sellyoursaas/scripts/deployment_deploy_module.php {{command}} {{productref}} {{instancefilter}} allow {{master_instance_id}} {{countrycode}} {{nocache}}
+    command: "{{ sellyoursaasdir }}/scripts/deployment_deploy_module.php {{command}} {{productref}} {{instancefilter}} allow {{master_instance_id}} {{countrycode}} {{nocache}}"
     register: command_output
 
   - debug:

--- a/scripts/ansible/launch_git_update_sellyoursaas.yml
+++ b/scripts/ansible/launch_git_update_sellyoursaas.yml
@@ -11,8 +11,18 @@
   become_method: sudo
   become_user: admin
   tasks:
+  - name: Read sellyoursaasdir from /etc/sellyoursaas.conf
+    shell: "grep '^sellyoursaasdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2"
+    register: sellyoursaasdir_result
+    changed_when: false
+    failed_when: false
+
+  - name: Fall back to the documented default sellyoursaasdir if not set in /etc/sellyoursaas.conf
+    set_fact:
+      sellyoursaasdir: "{{ sellyoursaasdir_result.stdout if sellyoursaasdir_result.stdout != '' else '/home/admin/wwwroot/dolibarr_sellyoursaas' }}"
+
   - name: Launch git_update_sellyoursaas.sh
-    command: /home/admin/wwwroot/dolibarr_sellyoursaas/scripts/git_update_sellyoursaas.sh /home/admin/wwwroot/
+    command: "{{ sellyoursaasdir }}/scripts/git_update_sellyoursaas.sh {{ sellyoursaasdir | dirname }}/"
     register: command_output
 
   - debug:

--- a/scripts/ansible/launch_install_check.yml
+++ b/scripts/ansible/launch_install_check.yml
@@ -1955,6 +1955,16 @@
   become_method: sudo
   become_user: root
   tasks:
+    - name: Read sellyoursaasdir from /etc/sellyoursaas.conf
+      shell: "grep '^sellyoursaasdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2"
+      register: sellyoursaasdir_result
+      changed_when: false
+      failed_when: false
+
+    - name: Fall back to the documented default sellyoursaasdir if not set in /etc/sellyoursaas.conf
+      set_fact:
+        sellyoursaasdir: "{{ sellyoursaasdir_result.stdout if sellyoursaasdir_result.stdout != '' else '/home/admin/wwwroot/dolibarr_sellyoursaas' }}"
+
     #- name: Set sshd config files /etc/ssh/sshd_config.d/sellyousaas.conf
     #  ansible.builtin.template:
     #    src: ../../etc/ssh/sshd_config.d/sellyoursaas.conf
@@ -2051,7 +2061,7 @@
     # Fail2ban rules
     - name: Search all fail2ban rules into filter.d directory
       ansible.builtin.find:
-        paths: /home/admin/wwwroot/dolibarr_sellyoursaas/etc/fail2ban/filter.d
+        paths: "{{ sellyoursaasdir }}/etc/fail2ban/filter.d"
         patterns: '*.conf'
       register: dolibarr_fail2ban_files
 
@@ -2067,7 +2077,7 @@
 
     - name: Search all fail2ban rules into jail.d directory
       ansible.builtin.find:
-        paths: /home/admin/wwwroot/dolibarr_sellyoursaas/etc/fail2ban/jail.d
+        paths: "{{ sellyoursaasdir }}/etc/fail2ban/jail.d"
         patterns: '*.conf'
         file_type: file
       register: dolibarr_fail2ban_files2
@@ -2161,8 +2171,18 @@
   become_method: sudo
   become_user: root
   tasks:
+  - name: Read sellyoursaasdir from /etc/sellyoursaas.conf
+    shell: "grep '^sellyoursaasdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2"
+    register: sellyoursaasdir_result
+    changed_when: false
+    failed_when: false
+
+  - name: Fall back to the documented default sellyoursaasdir if not set in /etc/sellyoursaas.conf
+    set_fact:
+      sellyoursaasdir: "{{ sellyoursaasdir_result.stdout if sellyoursaasdir_result.stdout != '' else '/home/admin/wwwroot/dolibarr_sellyoursaas' }}"
+
   - name: Launch perms.sh to set permissions, create some dirs and files
-    command: "/home/admin/wwwroot/dolibarr_sellyoursaas/scripts/perms.sh confirm"
+    command: "{{ sellyoursaasdir }}/scripts/perms.sh confirm"
     register: command_output
     changed_when: false
 

--- a/scripts/ansible/user_create.yml
+++ b/scripts/ansible/user_create.yml
@@ -16,19 +16,29 @@
   #become_method: sudo
   become_user: root
   tasks:
+  - name: Read sellyoursaasdir from /etc/sellyoursaas.conf
+    shell: "grep '^sellyoursaasdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2"
+    register: sellyoursaasdir_result
+    changed_when: false
+    failed_when: false
+
+  - name: Fall back to the documented default sellyoursaasdir if not set in /etc/sellyoursaas.conf
+    set_fact:
+      sellyoursaasdir: "{{ sellyoursaasdir_result.stdout if sellyoursaasdir_result.stdout != '' else '/home/admin/wwwroot/dolibarr_sellyoursaas' }}"
+
   - name: Check if SellYourSaas is installed on this sevrer
-    stat: 
-      path: /home/admin/wwwroot/dolibarr_sellyoursaas/scripts/ansible/info_users.php
+    stat:
+      path: "{{ sellyoursaasdir }}/scripts/ansible/info_users.php"
     register: sellyoursaas_installed_rules
 
   - name: Get the user main public ip into the variable command_for_userip
-    command: "/home/admin/wwwroot/dolibarr_sellyoursaas/scripts/ansible/info_users.php ip {{login}}"
+    command: "{{ sellyoursaasdir }}/scripts/ansible/info_users.php ip {{login}}"
     register: command_for_userip
     when: sellyoursaas_installed_rules.stat.exists == True
     changed_when: false
 
   - name: Get the user public key into the variable command_for_userpublickey if userpublickey not provided as parameter
-    command: "/home/admin/wwwroot/dolibarr_sellyoursaas/scripts/ansible/info_users.php public_key {{login}}"
+    command: "{{ sellyoursaasdir }}/scripts/ansible/info_users.php public_key {{login}}"
     register: command_for_userpublickey
     when: 
       - sellyoursaas_installed_rules.stat.exists == True

--- a/scripts/backup_mysql_system.sh
+++ b/scripts/backup_mysql_system.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Purge data
 #
-# Put the following entry into your root cron
+# Put the following entry into your root cron (adjust the path if sellyoursaasdir is
+# customized in /etc/sellyoursaas.conf)
 #40 4 4 * * /home/admin/wwwroot/dolibarr_sellyoursaas/scripts/backup_mysql_system.sh databasename confirm
 
 #set -e

--- a/scripts/backup_pull_backups.sh
+++ b/scripts/backup_pull_backups.sh
@@ -2,6 +2,7 @@
 # Catch backups from a remote backup server into a local computer, like a NAS.
 #
 # Put the following entry into the cron of a user that can rsync to the remote server with its public key.
+# (adjust the path if sellyoursaasdir is customized in /etc/sellyoursaas.conf)
 # /home/admin/wwwroot/dolibarr_sellyoursaas/scripts/backup_pull_backups.php  remotelogin  (test|confirm)  [remotebackupserversrc]  [localdirtarget]  >/.../backup_backup_backups.log
 #
 # On a NAS (Synology, ...), after beeing logged in ssh (for example with "ssh -p 1022 -l mylogin ip.of.nas) the file can be stored into:

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -2,7 +2,8 @@
 # Purge data.
 # This script can be run on the master or any deployment servers.
 #
-# Put the following entry into your root cron
+# Put the following entry into your root cron (adjust the path if sellyoursaasdir is
+# customized in /etc/sellyoursaas.conf)
 #40 4 4 * * /home/admin/wwwroot/dolibarr_sellyoursaas/scripts/clean.sh confirm
 
 #set -e

--- a/scripts/deployment_migrate_server_http2.sh
+++ b/scripts/deployment_migrate_server_http2.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+#
+# One-time, per-deployment-server migration from mpm_itk (mod_php or php-fpm era) to
+# mpm_event + HTTP/2. Requires phpfpm=1 and phpversion=<server default> already set in
+# /etc/sellyoursaas.conf. Any vhost still on mod_php gets switched to that default PHP-FPM
+# version first (via switch_instance_phpversion.sh, one instance at a time) before the MPM
+# switch, so isolation (currently from mpm_itk's OS-user switching) is never dropped before
+# each instance has its own php-fpm pool to fall back on.
+#
+# Why this is needed: mod_http2 refuses to load under mpm_prefork (which mpm_itk is built
+# on), so HTTP/2 requires mpm_event. But mpm_event has no per-vhost UID switching, so Apache
+# then runs every vhost as one shared user (www-data). PHP execution stays isolated per
+# client via each php-fpm pool's own user (already the case since the php-fpm migration),
+# but www-data still needs read+traverse on each instance's htdocs/ to serve static files
+# and hand .php requests off to the fcgi socket - documents/ (private Dolibarr data) is
+# never Aliased into any vhost and is only ever reached through an authenticated PHP script
+# running under the instance's own pool user, so it must stay fully unreadable by www-data.
+#
+# Safe to re-run: every step here is idempotent.
+
+set -e
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Checking prerequisites"
+
+if [[ "$(id -u)" != "0" ]]; then
+	echo "This script must be run as root" 1>&2
+	exit 1
+fi
+
+phpfpm=$(grep '^phpfpm=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+if [[ "x$phpfpm" == "x" ]]; then
+	echo "Error: phpfpm= is not set in /etc/sellyoursaas.conf. Migrate this server's instances to php-fpm before running this script." 1>&2
+	exit 1
+fi
+
+defaultphpversion=$(grep '^phpversion=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+if [[ "x$defaultphpversion" == "x" ]]; then
+	echo "Error: phpversion= is not set in /etc/sellyoursaas.conf (server default PHP-FPM version)" 1>&2
+	exit 1
+fi
+
+masterdbhost=$(grep '^databasehost=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+masterdbport=$(grep '^databaseport=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+masterdbuser=$(grep '^databaseuser=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+masterdbpass=$(grep '^databasepass=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+masterdbname=$(grep '^database=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+if [[ "x$masterdbhost" == "x" || "x$masterdbname" == "x" ]]; then
+	echo "Error: could not read the master database connection details from /etc/sellyoursaas.conf" 1>&2
+	exit 1
+fi
+mastermysql() {
+	mysql -h "$masterdbhost" -P "$masterdbport" -u "$masterdbuser" -p"$masterdbpass" "$masterdbname" --default-character-set=utf8 -N -e "$1"
+}
+
+# The Dolibarr table prefix defaults to llx_ but is configurable per install (dolibarr_main_db_prefix
+# in conf.php); read the local Dolibarr's conf.php to get the prefix actually used by this master database.
+dolibarrdir=$(grep '^dolibarrdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+dbprefix=llx_
+if [[ "x$dolibarrdir" != "x" && -f "$dolibarrdir/htdocs/conf/conf.php" ]]; then
+	confprefix=$(grep -vE '^\s*//' "$dolibarrdir/htdocs/conf/conf.php" 2>/dev/null | grep -oP "dolibarr_main_db_prefix\s*=\s*[\"']\K[^\"']+" || true)
+	if [[ "x$confprefix" != "x" ]]; then
+		dbprefix=$confprefix
+	fi
+fi
+
+# Nothing enforces that this locally-read prefix actually matches the master database's real
+# table prefix (the rest of the module - batch_customers.php and friends - makes the exact same
+# unchecked assumption); fail clearly here instead of a confusing "table doesn't exist" further down.
+mastermysqlerror=$(mastermysql "SELECT 1 FROM ${dbprefix}const LIMIT 1" 2>&1 >/dev/null)
+if [[ $? -ne 0 ]]; then
+	echo "Error: could not query ${dbprefix}const on the master database ($masterdbname@$masterdbhost) - check the master database credentials in /etc/sellyoursaas.conf, and that '$dbprefix' (from $dolibarrdir/htdocs/conf/conf.php, or the llx_ default if that file wasn't found) actually matches the table prefix used on the master database." 1>&2
+	echo "$mastermysqlerror" 1>&2
+	exit 1
+fi
+
+enableoverride=$(mastermysql "SELECT value FROM ${dbprefix}const WHERE name='SELLYOURSAAS_ENABLE_PHPVERSION_OVERRIDE' AND entity=1" 2>/dev/null)
+if [[ "x$enableoverride" != "x1" ]]; then
+	echo "Error: SELLYOURSAAS_ENABLE_PHPVERSION_OVERRIDE is not enabled on the master server (Home - Setup - Other). Enable it before running this migration." 1>&2
+	exit 1
+fi
+
+if ! apache2ctl -M 2>/dev/null | grep -q proxy_fcgi_module; then
+	echo "Error: mod_proxy_fcgi is not enabled - needed before any mod_php instance can be switched to php-fpm." 1>&2
+	echo "Run 'a2enmod proxy proxy_fcgi', then 'systemctl restart apache2' (a2enmod alone is not enough, this needs a full restart), then re-run this script." 1>&2
+	exit 1
+fi
+
+scriptdir=$(dirname "$(realpath "$0")")
+modphpvhosts=$(grep -L 'fpm-.*\.sock' /etc/apache2/sellyoursaas-enabled/*.conf 2>/dev/null || true)
+if [[ "x$modphpvhosts" != "x" ]]; then
+	echo "$(date +'%Y-%m-%d %H:%M:%S') ***** The following vhosts are still on mod_php, switching them to php-fpm $defaultphpversion (the server default) first:"
+	echo "$modphpvhosts"
+	while IFS= read -r vhost; do
+		[ -n "$vhost" ] || continue
+		fqn=$(basename "$vhost" .conf)
+		documentroot=$(grep -oP '(?<=DocumentRoot )\S+' "$vhost" | head -1)
+		documentroot=${documentroot%/htdocs}
+		if [[ "x$documentroot" == "x" || ! -d "$documentroot" ]]; then
+			echo "Error: could not find the instance directory for $fqn from $vhost's DocumentRoot" 1>&2
+			exit 1
+		fi
+		osusername=$(stat -c '%U' "$documentroot")
+		"$scriptdir/switch_instance_phpversion.sh" "$fqn" "$osusername" "$documentroot" "$defaultphpversion"
+	done <<< "$modphpvhosts"
+fi
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') All vhosts are now on php-fpm, continuing"
+
+# Instances already on php-fpm before this script ever ran (e.g. deployed straight onto
+# php-fpm, or switched manually) never went through switch_instance_phpversion.sh above,
+# so their contract 'PHP version' field may never have been synced - visit them too, passing
+# their own current version (a no-op on the server, but triggers the contract-field sync).
+alreadyfpmvhosts=$(grep -l 'fpm-.*\.sock' /etc/apache2/sellyoursaas-enabled/*.conf 2>/dev/null | grep -v '\.custom[0-9]*\.conf$' || true)
+if [[ "x$alreadyfpmvhosts" != "x" ]]; then
+	echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Syncing the contract 'PHP version' field for vhosts already on php-fpm before this script ran:"
+	while IFS= read -r vhost; do
+		[ -n "$vhost" ] || continue
+		fqn=$(basename "$vhost" .conf)
+		currentphpversion=$(grep -oP "(?<=php)[0-9]+\.[0-9]+(?=-fpm-${fqn//./\\.}\.sock)" "$vhost" | head -1)
+		[ -n "$currentphpversion" ] || continue
+		documentroot=$(grep -oP '(?<=DocumentRoot )\S+' "$vhost" | head -1)
+		documentroot=${documentroot%/htdocs}
+		[[ "x$documentroot" != "x" && -d "$documentroot" ]] || continue
+		osusername=$(stat -c '%U' "$documentroot")
+		"$scriptdir/switch_instance_phpversion.sh" "$fqn" "$osusername" "$documentroot" "$currentphpversion"
+	done <<< "$alreadyfpmvhosts"
+fi
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Installing acl package"
+if ! command -v setfacl >/dev/null 2>&1; then
+	DEBIAN_FRONTEND=noninteractive apt-get install -y acl
+fi
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Granting www-data read+traverse on htdocs for every existing instance (documents/ stays untouched)"
+for d in /home/jail/home/*/*/htdocs; do
+	[ -d "$d" ] || continue
+	parent=$(dirname "$d")
+	grandparent=$(dirname "$parent")
+	echo "  $d"
+	setfacl -m g:www-data:--x "$grandparent"
+	setfacl -m g:www-data:--x "$parent"
+	setfacl -R -m g:www-data:rX "$d"
+	setfacl -d -m g:www-data:rX "$d"
+done
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Verifying www-data can read htdocs but not documents/"
+failed=0
+for d in /home/jail/home/*/*/htdocs; do
+	[ -d "$d" ] || continue
+	f=$(find "$d" -maxdepth 1 -type f | head -1)
+	if [ -n "$f" ] && ! sudo -u www-data test -r "$f"; then
+		echo "  FAIL: www-data cannot read $f" 1>&2
+		failed=1
+	fi
+done
+for d in /home/jail/home/*/*/documents; do
+	[ -d "$d" ] || continue
+	if sudo -u www-data test -r "$d"; then
+		echo "  FAIL: www-data can read $d (should stay blocked)" 1>&2
+		failed=1
+	fi
+done
+if [[ "$failed" != "0" ]]; then
+	echo "Error: ACL verification failed, aborting before touching the MPM (nothing web-facing changed yet)" 1>&2
+	exit 1
+fi
+echo "$(date +'%Y-%m-%d %H:%M:%S') ACL verification OK"
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Fixing up existing php-fpm pools created before listen.group was www-data"
+for poolconf in /etc/php/*/fpm/pool.d/sellyoursaas/*.phpfpm.conf; do
+	[ -f "$poolconf" ] || continue
+	if grep -q '^listen.group = www-data$' "$poolconf"; then
+		continue
+	fi
+	echo "  $poolconf"
+	sed -i -E 's/^listen\.group = .*/listen.group = www-data/' "$poolconf"
+	if ! grep -q '^listen.mode' "$poolconf"; then
+		sed -i '/^listen.group = www-data$/a listen.mode = 0660' "$poolconf"
+	fi
+	phpversion=$(echo "$poolconf" | sed -n 's#/etc/php/\([0-9.]*\)/fpm/.*#\1#p')
+	fqn=$(basename "$poolconf" .phpfpm.conf)
+	systemctl restart "sellyoursaas-php${phpversion}-fpm-${fqn}.service"
+done
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Neutralizing the now-invalid php_admin_value open_basedir line (mod_php will be disabled below; open_basedir is already enforced per-pool by php-fpm)"
+for vhost in /etc/apache2/sellyoursaas-available/*.conf /etc/apache2/sellyoursaas-enabled/*.conf; do
+	[ -f "$vhost" ] || continue
+	[ -L "$vhost" ] && continue
+	sed -i 's/^\([[:space:]]*\)php_admin_value open_basedir/\1#php_admin_value open_basedir/' "$vhost"
+done
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Switching MPM from itk/prefork to event and enabling HTTP/2"
+apache2ctl configtest
+# a2query -m reports the a2enmod/a2dismod name (eg. "php7.4", "php8.3" - stable across Ubuntu
+# 22.04/24.04, Debian package naming convention), NOT apache2ctl -M's internal module symbol
+# (always "php7_module" for the whole 7.x branch, "php_module" for 8.x - never version-specific,
+# so grepping for "php[0-9]+\.[0-9]+" in apache2ctl -M's output never matches anything there).
+enabledphpmods=$(a2query -m 2>/dev/null | grep -oE '^php[0-9]+\.[0-9]+' || true)
+for enabledphpmod in $enabledphpmods; do
+	a2dismod "$enabledphpmod"
+done
+a2dismod mpm_itk 2>/dev/null || true
+a2dismod mpm_prefork
+rm -f /etc/apache2/mods-enabled/mpm_itk.conf
+a2enmod mpm_event
+a2enmod http2
+apache2ctl configtest
+systemctl restart apache2
+systemctl is-active apache2
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Done. Verify with: curl -sk --http2 -A 'Mozilla/5.0' -o /dev/null -w 'Protocol: %{http_version}\n' https://<a-domain-on-this-server>/ --resolve <domain>:443:127.0.0.1"

--- a/scripts/deployment_setup_phpfpm.sh
+++ b/scripts/deployment_setup_phpfpm.sh
@@ -1,0 +1,304 @@
+#!/bin/bash
+#
+# One-time preparation of a deployment server for PHP-FPM with one or more PHP
+# versions, before any instance is switched and before scripts/deployment_migrate_server_http2.sh
+# can run. Idempotent: safe to re-run, eg. to add one more PHP version later.
+#
+# Usage: deployment_setup_phpfpm.sh <default_version> <version> [version...]
+# Example: deployment_setup_phpfpm.sh 8.3 8.1 8.2 8.3 8.4
+#   - installs php-fpm + a standard extension set for every <version> listed
+#   - makes <default_version> (must be one of the versions listed) the one
+#     whose own distro php<version>-fpm.service stays enabled; the others are masked
+#   - sets phpfpm=1 and phpversion=<default_version> in /etc/sellyoursaas.conf
+#   - enables mod_proxy_fcgi and restarts Apache
+#   - refreshes the jailkit common jail AND every existing private jail (sshaccesstype=2
+#     instances each got their own full copy at deploy time, they don't share commonjail)
+#     so SSH/SFTP users get a matching php<version> CLI binary for every version above,
+#     plus whatever PHP version mod_php is currently serving (if any - existing instances
+#     keep using it until migrated). Skipped entirely if this server isn't using jailkit.
+#
+# What this script does NOT do: touch any existing vhost, or run
+# scripts/deployment_migrate_server_http2.sh's MPM switch. Existing instances keep running
+# under mod_php until migrated individually (contract PHP version field, which
+# calls scripts/switch_instance_phpversion.sh) or in bulk later.
+
+set -e
+
+if [[ "$(id -u)" != "0" ]]; then
+	echo "This script must be run as root" 1>&2
+	exit 1
+fi
+
+if [[ $# -lt 2 ]]; then
+	echo "Usage: $0 <default_version> <version> [version...]" 1>&2
+	echo "Example: $0 8.3 8.1 8.2 8.3 8.4" 1>&2
+	exit 1
+fi
+
+defaultphpversion=$1
+shift
+versions="$*"
+
+case " $versions " in
+	*" $defaultphpversion "*) ;;
+	*)
+		echo "Error: default version $defaultphpversion must be one of the versions listed: $versions" 1>&2
+		exit 1
+		;;
+esac
+
+masterdbhost=$(grep '^databasehost=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+masterdbport=$(grep '^databaseport=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+masterdbuser=$(grep '^databaseuser=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+masterdbpass=$(grep '^databasepass=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+masterdbname=$(grep '^database=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+if [[ "x$masterdbhost" == "x" || "x$masterdbname" == "x" ]]; then
+	echo "Error: could not read the master database connection details from /etc/sellyoursaas.conf" 1>&2
+	exit 1
+fi
+mastermysql() {
+	mysql -h "$masterdbhost" -P "$masterdbport" -u "$masterdbuser" -p"$masterdbpass" "$masterdbname" --default-character-set=utf8 -N -e "$1"
+}
+
+# The Dolibarr table prefix defaults to llx_ but is configurable per install (dolibarr_main_db_prefix
+# in conf.php); read the local Dolibarr's conf.php to get the prefix actually used by this master database.
+dolibarrdir=$(grep '^dolibarrdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+dbprefix=llx_
+if [[ "x$dolibarrdir" != "x" && -f "$dolibarrdir/htdocs/conf/conf.php" ]]; then
+	confprefix=$(grep -vE '^\s*//' "$dolibarrdir/htdocs/conf/conf.php" 2>/dev/null | grep -oP "dolibarr_main_db_prefix\s*=\s*[\"']\K[^\"']+" || true)
+	if [[ "x$confprefix" != "x" ]]; then
+		dbprefix=$confprefix
+	fi
+fi
+
+# Nothing enforces that this locally-read prefix actually matches the master database's real
+# table prefix (the rest of the module - batch_customers.php and friends - makes the exact same
+# unchecked assumption); fail clearly here instead of a confusing "table doesn't exist" further down.
+mastermysqlerror=$(mastermysql "SELECT 1 FROM ${dbprefix}const LIMIT 1" 2>&1 >/dev/null)
+if [[ $? -ne 0 ]]; then
+	echo "Error: could not query ${dbprefix}const on the master database ($masterdbname@$masterdbhost) - check the master database credentials in /etc/sellyoursaas.conf, and that '$dbprefix' (from $dolibarrdir/htdocs/conf/conf.php, or the llx_ default if that file wasn't found) actually matches the table prefix used on the master database." 1>&2
+	echo "$mastermysqlerror" 1>&2
+	exit 1
+fi
+
+enableoverride=$(mastermysql "SELECT value FROM ${dbprefix}const WHERE name='SELLYOURSAAS_ENABLE_PHPVERSION_OVERRIDE' AND entity=1" 2>/dev/null)
+if [[ "x$enableoverride" != "x1" ]]; then
+	echo "Error: SELLYOURSAAS_ENABLE_PHPVERSION_OVERRIDE is not enabled on the master server (Home - Setup - Other). Enable it before setting up PHP-FPM on this server." 1>&2
+	exit 1
+fi
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Checking Sury PPA support for this OS"
+codename=$(lsb_release -cs 2>/dev/null || . /etc/os-release && echo "$VERSION_CODENAME")
+if ! curl -fsSL "https://packages.sury.org/php/dists/" 2>/dev/null | grep -q ">$codename/<"; then
+	echo "Error: Sury's PHP PPA has no '$codename' distribution - this OS is too old (or too new) to install extra PHP versions this way." 1>&2
+	echo "Check https://packages.sury.org/php/dists/ for supported distributions. Upgrading the OS is the usual fix (see do-release-upgrade)." 1>&2
+	exit 1
+fi
+echo "$(date +'%Y-%m-%d %H:%M:%S') Sury supports $codename, continuing"
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Adding the Sury PHP PPA"
+if [ ! -f /etc/apt/sources.list.d/php-sury.list ]; then
+	apt-get install -y ca-certificates apt-transport-https curl
+	curl -fsSL https://packages.sury.org/php/apt.gpg -o /usr/share/keyrings/deb.sury.org-php.gpg
+	echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $codename main" > /etc/apt/sources.list.d/php-sury.list
+fi
+apt-get update
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Installing PHP-FPM and extensions for: $versions"
+exts="apcu bz2 cli common curl fpm gd igbinary imagick imap intl ldap mbstring memcached msgpack mysql opcache readline ssh2 xdebug xml zip"
+for v in $versions; do
+	echo "$(date +'%Y-%m-%d %H:%M:%S') --- php$v ---"
+	pkgs=""
+	for e in $exts; do
+		pkg="php$v-$e"
+		if apt-cache show "$pkg" >/dev/null 2>&1; then
+			pkgs="$pkgs $pkg"
+		else
+			echo "  skipping $pkg (not available for PHP $v on this distribution)"
+		fi
+	done
+	DEBIAN_FRONTEND=noninteractive apt-get install -y $pkgs
+done
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Masking the default php-fpm service for every non-default version"
+for v in $versions; do
+	if [[ "$v" == "$defaultphpversion" ]]; then
+		systemctl unmask "php$v-fpm" 2>/dev/null || true
+		systemctl enable --now "php$v-fpm"
+	else
+		systemctl disable --now "php$v-fpm" 2>/dev/null || true
+		systemctl mask "php$v-fpm"
+	fi
+done
+
+# A handful of extensions (imagick, ssh2, xdebug at least) are not built per PHP version by
+# Sury - installing any of them pulls in a version-independent package that registers itself
+# against every PHP ABI already present on the system via a packaging trigger, which can
+# silently apt-get install (and systemd auto-enables) a whole extra php<version>-fpm this
+# script never asked for and knows nothing about. Mask any php-fpm service on disk that isn't
+# one of the versions actually requested, whatever pulled it in.
+for unit in /usr/lib/systemd/system/php*-fpm.service /lib/systemd/system/php*-fpm.service; do
+	[ -f "$unit" ] || continue
+	v=$(basename "$unit" | sed -n 's/^php\([0-9.]*\)-fpm\.service$/\1/p')
+	[[ "x$v" != "x" ]] || continue
+	case " $versions " in
+		*" $v "*) ;;
+		*)
+			echo "  php$v-fpm was not requested (pulled in as a side dependency) - masking it"
+			systemctl disable --now "php$v-fpm" 2>/dev/null || true
+			systemctl mask "php$v-fpm"
+			;;
+	esac
+done
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Creating pool.d/sellyoursaas for every version"
+for v in $versions; do
+	mkdir -p "/etc/php/$v/fpm/pool.d/sellyoursaas"
+	chown root:root "/etc/php/$v/fpm/pool.d/sellyoursaas"
+	chmod 755 "/etc/php/$v/fpm/pool.d/sellyoursaas"
+done
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Enabling /etc/php/sellyoursaas.ini (auto_prepend_file, upload limits...) for fpm"
+for v in $versions; do
+	ln -fs /etc/php/sellyoursaas.ini "/etc/php/$v/fpm/conf.d/sellyoursaas.ini"
+	if systemctl is-active --quiet "php$v-fpm"; then
+		systemctl reload "php$v-fpm"
+	fi
+done
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Deploying the php-fpm AppArmor local override"
+imagickdir=$(basename "$(ls -d /etc/ImageMagick-* 2>/dev/null | head -1)")
+if [[ "x$imagickdir" == "x" ]]; then
+	echo "Warning: no /etc/ImageMagick-* found, skipping the ImageMagick allowance in the AppArmor override (add it by hand if ImageMagick gets installed later)."
+	imagickdir="ImageMagick-6"
+fi
+cat > /etc/apparmor.d/local/php-fpm << EOF
+owner /run/systemd/notify w,
+# added by claude migration - allow ImageMagick policy read
+/etc/$imagickdir/*.xml r,
+/usr/share/$imagickdir/*.xml r,
+/etc/$imagickdir/*.xml.dpkg-new r,
+# added by claude migration - allow per-instance fpm socket/pid naming
+/run/php/php*-fpm-*.sock rwlk,
+/run/php/php*-fpm-*.pid rw,
+# added by claude migration - allow reading/writing instance webroots (isolation enforced by open_basedir per pool)
+/home/jail/home/** rwk,
+EOF
+chown root:root /etc/apparmor.d/local/php-fpm
+chmod 644 /etc/apparmor.d/local/php-fpm
+apparmor_parser -r /etc/apparmor.d/php-fpm
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Setting phpfpm=1 and phpversion=$defaultphpversion in /etc/sellyoursaas.conf"
+if grep -q '^phpfpm=' /etc/sellyoursaas.conf; then
+	sed -i "s/^phpfpm=.*/phpfpm=1/" /etc/sellyoursaas.conf
+else
+	printf '\nphpfpm=1\n' >> /etc/sellyoursaas.conf
+fi
+if grep -q '^phpversion=' /etc/sellyoursaas.conf; then
+	sed -i "s/^phpversion=.*/phpversion=$defaultphpversion/" /etc/sellyoursaas.conf
+else
+	printf 'phpversion=%s\n' "$defaultphpversion" >> /etc/sellyoursaas.conf
+fi
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Enabling mod_proxy_fcgi (needs a full Apache restart to take effect)"
+a2enmod proxy proxy_fcgi
+apache2ctl configtest
+systemctl restart apache2
+systemctl is-active apache2
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Refreshing the jailkit common jail"
+chrootdir=$(grep '^chrootdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+if ! command -v jk_init >/dev/null 2>&1; then
+	echo "jailkit is not installed on this server (SSH access is not jailed here), skipping the jail refresh."
+elif [[ "x$chrootdir" == "x" ]]; then
+	echo "chrootdir= is not set in /etc/sellyoursaas.conf, this server is not using jailkit for SellYourSaaS, skipping the jail refresh."
+elif ! grep -q '^\[php\]' /etc/jailkit/jk_init.ini; then
+	echo "Warning: jailkit is installed and chrootdir= is set, but /etc/jailkit/jk_init.ini has no [php] section yet - this server's jail was never set up per the Jailkit section of the doc. Skipping the jail refresh (add the [php]/[env]/[mysqlclient] sections by hand first, then re-run this script)."
+else
+	# a2query -m reports the a2enmod/a2dismod name (eg. "php7.4", "php8.3" - stable across Ubuntu
+	# 22.04/24.04, Debian package naming convention), NOT apache2ctl -M's internal module symbol
+	# (always "php7_module" for the whole 7.x branch, "php_module" for 8.x - never version-specific,
+	# so grepping for "php[0-9]+\.[0-9]+" in apache2ctl -M's output never matches anything there).
+	currentmodphp=$(a2query -m 2>/dev/null | grep -oE '^php[0-9]+\.[0-9]+' | head -1 || true)
+	jailversions="$versions"
+	if [[ "x$currentmodphp" != "x" ]]; then
+		case " $jailversions " in
+			*" ${currentmodphp#php} "*) ;;
+			*) jailversions="$jailversions ${currentmodphp#php}" ;;
+		esac
+	fi
+	execs="/usr/bin/php"
+	for v in $jailversions; do
+		if [ -x "/usr/bin/php$v" ]; then
+			execs="$execs, /usr/bin/php$v"
+		fi
+	done
+	sed -i "s#^executables = /usr/bin/php.*#executables = $execs#" /etc/jailkit/jk_init.ini
+	echo "  jk_init.ini [php] executables now: $execs"
+
+	rm -rf /home/jail/chroot/template
+	mkdir /home/jail/chroot/template
+	jk_init -c /etc/jailkit/jk_init.ini -j /home/jail/chroot/template extendedshell limitedshell groups sftp rsync editors git php mysqlclient acl
+	mkdir -p /home/jail/chroot/template/home /home/jail/chroot/template/tmp
+	chmod 1777 /home/jail/chroot/template/tmp
+
+	templatesdir=$(grep '^templatesdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+	if [[ "x$templatesdir" != "x" ]]; then
+		cd /home/jail/chroot
+		tar --zstd -cf commonjail.tar.zst template
+		tar --zstd -cf privatejail.tar.zst template
+		backupdir="$templatesdir/old-jail-backup-$(date +%Y%m%d-%H%M%S)"
+		mkdir -p "$backupdir"
+		[ -f "$templatesdir/commonjail.tar.zst" ] && mv "$templatesdir/commonjail.tar.zst" "$backupdir/"
+		[ -f "$templatesdir/privatejail.tar.zst" ] && mv "$templatesdir/privatejail.tar.zst" "$backupdir/"
+		cp commonjail.tar.zst privatejail.tar.zst "$templatesdir/"
+		chown nobody:nogroup "$templatesdir/commonjail.tar.zst" "$templatesdir/privatejail.tar.zst" 2>/dev/null || true
+	fi
+
+	# /etc/passwd, /etc/group (and their -/shadow variants) are NOT part of the software
+	# refreshed here - jk_init only ever seeds them with root/system accounts, and every real
+	# jailed user then gets added to the LIVE jail's own copy by jk_jailuser at deploy time
+	# (see action_deploy_undeploy.sh). Syncing the freshly rebuilt template's minimal versions
+	# over them would wipe out every already-deployed user, breaking their SSH/SFTP access and
+	# any cron (eg. backups) that logs in as them - found and fixed the hard way on this exact
+	# set of servers, see the commit history.
+	jailidentityexcludes=(--exclude=/etc/passwd --exclude=/etc/passwd- --exclude=/etc/group --exclude=/etc/group- --exclude=/etc/shadow --exclude=/etc/shadow- --exclude=/etc/gshadow --exclude=/etc/gshadow-)
+
+	if [ -d /home/jail/chroot/commonjail ]; then
+		rsync -a "${jailidentityexcludes[@]}" /home/jail/chroot/template/ /home/jail/chroot/commonjail/
+		echo "  synced into the live commonjail"
+	fi
+
+	# Instances with sshaccesstype=2 (PrivateUserJail) each got their own full copy of this
+	# same template at deploy time (extracted from privatejail.tar.zst, then renamed to
+	# $chrootdir/$osusername) instead of sharing commonjail - refresh every one of them too,
+	# or they silently keep whatever PHP versions were available on the day they were deployed.
+	if [[ "x$chrootdir" != "x" && -d "$chrootdir" ]]; then
+		for onejail in "$chrootdir"/*/; do
+			onejail=${onejail%/}
+			base=$(basename "$onejail")
+			case "$base" in
+				commonjail|template) continue ;;
+			esac
+			[ -d "$onejail/usr/bin" ] || continue
+			rsync -a "${jailidentityexcludes[@]}" /home/jail/chroot/template/ "$onejail/"
+			echo "  synced into the private jail $onejail"
+		done
+	fi
+fi
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Updating this server's Deployment Server card on the master server"
+ownip=$(grep '^ipserverdeployment=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+if [[ "x$ownip" == "x" ]]; then
+	echo "Warning: ipserverdeployment= is not set in /etc/sellyoursaas.conf, skipping the Deployment Server card update - set phpversiondefault/phpversionsavailable/phpversionoverride by hand, or add ipserverdeployment= and re-run this script." 1>&2
+else
+	# Same detection command as the "Detect PHP versions" button (action "listphpversions"
+	# in scripts/remote_server/index.php), so the card ends up exactly as if that button had
+	# been clicked - this script is the single source of truth for this server's PHP-FPM setup.
+	phpversionsfound=$(ls -1 /usr/sbin/php-fpm* 2>/dev/null | grep -oP 'php-fpm\K[0-9]+\.[0-9]+$' | sort -u | paste -sd, -)
+	mastermysql "UPDATE ${dbprefix}sellyoursaas_deploymentserver SET phpversionsavailable='$phpversionsfound', phpversiondefault='$defaultphpversion', phpversionoverride=1 WHERE ipaddress='$ownip'"
+	echo "  phpversionsavailable=$phpversionsfound, phpversiondefault=$defaultphpversion, phpversionoverride=1 (ipaddress=$ownip)"
+fi
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Done. This server is now ready: switch existing instances individually"
+echo "(contract PHP version field, or scripts/deployment_migrate_server_http2.sh once all of them are on PHP-FPM)."

--- a/scripts/perms.sh
+++ b/scripts/perms.sh
@@ -28,6 +28,12 @@ if [[ "x$backupdir" == "x" ]]; then
 	export backupdir="/mnt/diskbackup/backup"
 fi
 
+# possibility to change the directory where the sellyoursaas module/repository itself is installed
+export sellyoursaasdir=`grep '^sellyoursaasdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
+if [[ "x$sellyoursaasdir" == "x" ]]; then
+	export sellyoursaasdir="/home/admin/wwwroot/dolibarr_sellyoursaas"
+fi
+
 echo "Search to know if we are a master server in /etc/sellyoursaas.conf"
 masterserver=`grep '^masterserver=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
 instanceserver=`grep '^instanceserver=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
@@ -119,10 +125,10 @@ if [ -d /home/admin/wwwroot/dolibarr_nltechno ]; then
 	chmod -R u+w /home/admin/wwwroot/dolibarr_nltechno/.git 2>/dev/null
 fi
 
-if [ -d /home/admin/wwwroot/dolibarr_sellyoursaas ]; then
-	echo Set owner and permission on /home/admin/wwwroot/dolibarr_sellyoursaas
-	chmod -R a-w /home/admin/wwwroot/dolibarr_sellyoursaas 2>/dev/null
-	chmod -R u+w /home/admin/wwwroot/dolibarr_sellyoursaas/.git 2>/dev/null
+if [ -d "$sellyoursaasdir" ]; then
+	echo Set owner and permission on $sellyoursaasdir
+	chmod -R a-w "$sellyoursaasdir" 2>/dev/null
+	chmod -R u+w "$sellyoursaasdir/.git" 2>/dev/null
 fi
 
 echo Set owner and permission on /home/admin/wwwroot/dolibarr/htdocs/conf/conf.php

--- a/scripts/remote_server/index.php
+++ b/scripts/remote_server/index.php
@@ -319,7 +319,7 @@ if (in_array($tmparray[0], array('deploywebsite'))) {
 	exit();
 }
 
-if (in_array($tmparray[0], array('deploycustomurl'))) {
+if (in_array($tmparray[0], array('deploycustomurl', 'changephpversion'))) {
 	if ($DEBUG) {
 		fwrite($fh, date('Y-m-d H:i:s').' ./action_customurl_instance.sh '.$tmparray[0].' '.$paramspace." \n");
 	} else {

--- a/scripts/switch_instance_phpversion.sh
+++ b/scripts/switch_instance_phpversion.sh
@@ -1,0 +1,271 @@
+#!/bin/bash
+#
+# Create/update the php-fpm pool and systemd service for one instance, and point every one
+# of its Apache vhosts' SetHandler at it - the main one plus any extra custom-URL vhost
+# ("<fqn>.custom.conf", "<fqn>.custom2.conf"...: one <VirtualHost> per custom domain, since
+# each needs its own SSL cert) - whether the instance is already on php-fpm (switching
+# version) or still on mod_php (first-time migration, no existing SetHandler to replace).
+#
+# Used by both action_customurl_instance.sh (mode changephpversion, one instance at a time
+# from a contract change) and deployment_migrate_server_http2.sh (looping over every remaining
+# mod_php instance on a server before it can drop mpm_itk for HTTP/2).
+#
+# Usage: switch_instance_phpversion.sh <fqn> <osusername> <instancedir> <newphpversion>
+#
+# Safe to re-run: does nothing if every vhost is already pointed at <newphpversion>.
+
+set -e
+
+fqn=$1
+osusername=$2
+instancedir=$3
+phpversion=$4
+
+if [[ "x$fqn" == "x" || "x$osusername" == "x" || "x$instancedir" == "x" || "x$phpversion" == "x" ]]; then
+	echo "Usage: $0 <fqn> <osusername> <instancedir> <newphpversion>" 1>&2
+	exit 1
+fi
+
+masterdbhost=$(grep '^databasehost=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+masterdbport=$(grep '^databaseport=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+masterdbuser=$(grep '^databaseuser=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+masterdbpass=$(grep '^databasepass=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+masterdbname=$(grep '^database=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+if [[ "x$masterdbhost" == "x" || "x$masterdbname" == "x" ]]; then
+	echo "Error: could not read the master database connection details from /etc/sellyoursaas.conf" 1>&2
+	exit 1
+fi
+mastermysql() {
+	mysql -h "$masterdbhost" -P "$masterdbport" -u "$masterdbuser" -p"$masterdbpass" "$masterdbname" --default-character-set=utf8 -N -e "$1"
+}
+
+# The Dolibarr table prefix defaults to llx_ but is configurable per install (dolibarr_main_db_prefix
+# in conf.php); read the local Dolibarr's conf.php to get the prefix actually used by this master database.
+dolibarrdir=$(grep '^dolibarrdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+dbprefix=llx_
+if [[ "x$dolibarrdir" != "x" && -f "$dolibarrdir/htdocs/conf/conf.php" ]]; then
+	confprefix=$(grep -vE '^\s*//' "$dolibarrdir/htdocs/conf/conf.php" 2>/dev/null | grep -oP "dolibarr_main_db_prefix\s*=\s*[\"']\K[^\"']+" || true)
+	if [[ "x$confprefix" != "x" ]]; then
+		dbprefix=$confprefix
+	fi
+fi
+
+# Nothing enforces that this locally-read prefix actually matches the master database's real
+# table prefix (the rest of the module - batch_customers.php and friends - makes the exact same
+# unchecked assumption); fail clearly here instead of a confusing "table doesn't exist" further down.
+mastermysqlerror=$(mastermysql "SELECT 1 FROM ${dbprefix}const LIMIT 1" 2>&1 >/dev/null)
+if [[ $? -ne 0 ]]; then
+	echo "Error: could not query ${dbprefix}const on the master database ($masterdbname@$masterdbhost) - check the master database credentials in /etc/sellyoursaas.conf, and that '$dbprefix' (from $dolibarrdir/htdocs/conf/conf.php, or the llx_ default if that file wasn't found) actually matches the table prefix used on the master database." 1>&2
+	echo "$mastermysqlerror" 1>&2
+	exit 1
+fi
+
+enableoverride=$(mastermysql "SELECT value FROM ${dbprefix}const WHERE name='SELLYOURSAAS_ENABLE_PHPVERSION_OVERRIDE' AND entity=1" 2>/dev/null)
+if [[ "x$enableoverride" != "x1" ]]; then
+	echo "Error: SELLYOURSAAS_ENABLE_PHPVERSION_OVERRIDE is not enabled on the master server (Home - Setup - Other). Enable it before switching any instance's PHP version." 1>&2
+	exit 1
+fi
+
+templatesdir=$(grep '^templatesdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+if [[ "x$templatesdir" == "x" ]]; then
+	templatesdir=$(dirname "$(realpath "$0")")/templates
+fi
+fpmpoolfiletemplate="$templatesdir/phppool-phpfpm.template"
+fpmservicefiletemplate="$templatesdir/poolservice-phpfpm.template"
+
+# php-fpm's open_basedir needs read access to the sellyoursaas module's own scripts/ directory
+# (eg. for phpsendmail.php/phpsendmailprepend.php) - same variable as action_deploy_undeploy.sh,
+# otherwise __sellyoursaasScriptsPath__ is left unsubstituted in the generated pool conf.
+sellyoursaasdir=$(grep '^sellyoursaasdir=' /etc/sellyoursaas.conf | cut -d '=' -f 2)
+if [[ "x$sellyoursaasdir" == "x" ]]; then
+	sellyoursaasdir="/home/admin/wwwroot/dolibarr_sellyoursaas"
+fi
+sellyoursaasscriptsdir="$sellyoursaasdir/scripts"
+
+if ! apache2ctl -M 2>/dev/null | grep -q proxy_fcgi_module; then
+	echo "Error: mod_proxy_fcgi is not enabled - the SetHandler this script writes into the vhost needs it to reach php-fpm." 1>&2
+	echo "Run 'a2enmod proxy proxy_fcgi', then 'systemctl restart apache2' (a2enmod alone is not enough, this needs a full restart), before retrying." 1>&2
+	exit 22
+fi
+
+apacheconf="/etc/apache2/sellyoursaas-available/$fqn.conf"
+if [ ! -f "$apacheconf" ]; then
+	echo "Error: vhost $apacheconf not found, cannot switch PHP version for an instance that does not seem deployed" 1>&2
+	exit 20
+fi
+
+# An instance can have extra custom-URL vhosts (one SSL cert per domain means one full
+# <VirtualHost> per domain, not just a ServerAlias on the main one) - only one of them is
+# ever known to Dolibarr (contract custom_url field, "<fqn>.custom.conf"); others may have
+# been added by hand ("<fqn>.custom2.conf", "<fqn>.custom3.conf"...), multi-URL support
+# being deferred for now. All of them proxy to the same php-fpm socket as the main vhost,
+# so every one of them needs the same SetHandler update, or it silently keeps serving the
+# old PHP version - or breaks outright once the old pool/service is torn down below.
+apacheconfs=$(
+	{
+		echo "$apacheconf"
+		ls /etc/apache2/sellyoursaas-available/"$fqn".custom*.conf 2>/dev/null
+		ls /etc/apache2/sellyoursaas-enabled/"$fqn".custom*.conf 2>/dev/null
+	} | xargs -r -I{} realpath {} | sort -u
+)
+echo "$(date +'%Y-%m-%d %H:%M:%S') Vhost(s) for $fqn:"
+echo "$apacheconfs" | sed 's/^/  /'
+
+# Always trust what the live main vhost is actually pointing to (empty if still on mod_php,
+# there's never been a SetHandler proxying to a php-fpm socket for this instance yet).
+currentphpversioninvhost=$(grep -oP "(?<=php)[0-9]+\.[0-9]+(?=-fpm-${fqn//./\\.}\.sock)" "$apacheconf" | head -1)
+echo "$(date +'%Y-%m-%d %H:%M:%S') ***** Switching PHP version of $fqn from '${currentphpversioninvhost:-mod_php}' to '$phpversion'"
+
+# Only skip everything (including the vhost loop below) if EVERY vhost already points at the
+# target version - a custom-URL vhost added or re-pointed after the last switch could still
+# be lagging behind even when the main one already matches.
+allvhostsalreadyonversion=1
+while IFS= read -r onevhost; do
+	[ -n "$onevhost" ] || continue
+	if ! grep -q "php$phpversion-fpm-$fqn.sock" "$onevhost"; then
+		allvhostsalreadyonversion=0
+		break
+	fi
+done <<< "$apacheconfs"
+if [[ "$allvhostsalreadyonversion" == "1" ]]; then
+	echo "Instance $fqn is already running PHP $phpversion on every vhost, nothing to do on the server"
+	# Still sync the contract field even on a no-op: an instance already on php-fpm before
+	# this script existed (or before SELLYOURSAAS_ENABLE_PHPVERSION_OVERRIDE was fixed) may
+	# never have had its 'PHP version' field written, and would otherwise never get fixed
+	# since it never goes through the switch logic below.
+	echo "$(date +'%Y-%m-%d %H:%M:%S') Syncing the 'PHP version' contract field on the master server, just in case it wasn't already"
+	mastermysql "UPDATE ${dbprefix}contrat_extrafields ce JOIN ${dbprefix}contrat c ON c.rowid = ce.fk_object SET ce.phpversion = '$phpversion' WHERE c.ref_customer = '$fqn' AND (ce.phpversion IS NULL OR ce.phpversion != '$phpversion')"
+	exit 0
+fi
+
+newphpfpmpooldir="/etc/php/$phpversion/fpm/pool.d/sellyoursaas"
+newphpfpmconf="$newphpfpmpooldir/$fqn.phpfpm.conf"
+newphpfpmservicename="sellyoursaas-php$phpversion-fpm-$fqn.service"
+newphpfpmservice="/etc/systemd/system/$newphpfpmservicename"
+
+mkdir -p "$newphpfpmpooldir"
+
+# Per-instance temp dir the pool conf points env TMP/TMPDIR/TEMP, sys_temp_dir and
+# upload_tmp_dir at instead of the shared system /tmp - may not exist yet for an instance
+# switching to php-fpm for the first time (action_deploy_undeploy.sh only creates it on deploy).
+# Owner needs fixing here (unlike on deploy) since this script never chowns the rest of
+# $instancedir - it already belongs to $osusername from the original deploy.
+mkdir -p "$instancedir/tmp"
+chown "$osusername:$osusername" "$instancedir/tmp"
+chmod go-rwxs "$instancedir/tmp"
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') Create php fpm pool conf $newphpfpmconf from $fpmpoolfiletemplate"
+sed -e "s;__fqn__;$fqn;g" \
+    -e "s;__phpversion__;$phpversion;g" \
+    -e "s;__osUsername__;$osusername;g" \
+    -e "s;__osGroupname__;$osusername;g" \
+    -e "s;__webAppPath__;$instancedir;g" \
+    -e "s;__sellyoursaasScriptsPath__;$sellyoursaasscriptsdir;g" \
+    "$fpmpoolfiletemplate" > "$newphpfpmconf"
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') Create php fpm service $newphpfpmservice from $fpmservicefiletemplate"
+sed -e "s;__fqn__;$fqn;g" \
+    -e "s;__phpversion__;$phpversion;g" \
+    "$fpmservicefiletemplate" > "$newphpfpmservice"
+
+systemctl daemon-reload
+systemctl enable --now "$newphpfpmservicename"
+sleep 1
+
+newsocket="/run/php/php$phpversion-fpm-$fqn.sock"
+if [ ! -S "$newsocket" ]; then
+	echo "Error: expected socket $newsocket not found after starting $newphpfpmservicename" 1>&2
+	exit 21
+fi
+
+while IFS= read -r onevhost; do
+	[ -n "$onevhost" ] || continue
+	cp -a "$onevhost" "$onevhost.bak-switchphpversion-$(date +%Y%m%d-%H%M%S)"
+
+	oneversioninvhost=$(grep -oP "(?<=php)[0-9]+\.[0-9]+(?=-fpm-${fqn//./\\.}\.sock)" "$onevhost" | head -1)
+	if [[ "x$oneversioninvhost" != "x" ]]; then
+		# Already on php-fpm: just repoint the existing SetHandler at the new socket
+		echo "$(date +'%Y-%m-%d %H:%M:%S') Update SetHandler in $onevhost to point to the new socket"
+		sed -i "s;php$oneversioninvhost-fpm-$fqn.sock;php$phpversion-fpm-$fqn.sock;g" "$onevhost"
+	else
+		# Still on mod_php: there is no SetHandler to replace, insert one fresh right after the
+		# first </IfModule> (the mpm_itk AssignUserID block, present in every vhost regardless
+		# of PHP mode), matching vhostHttps-phpfpm-sellyoursaas.template's own placement. Also
+		# neutralize php_admin_value open_basedir: it's an Apache/mod_php-only directive, invalid
+		# once mod_php is disabled, and redundant anyway since php-fpm enforces open_basedir
+		# per-pool (see php_admin_value[open_basedir] in phppool-phpfpm.template).
+		echo "$(date +'%Y-%m-%d %H:%M:%S') No existing php-fpm SetHandler in $onevhost (instance was on mod_php), inserting one"
+		awk -v socket="php$phpversion-fpm-$fqn.sock" '
+			{ print }
+			!done && /<\/IfModule>/ {
+				print ""
+				print "        # Indique a Apache d'"'"'utiliser le socket de PHP-FPM specifique"
+				print "        <FilesMatch \\.php$>"
+				print "            ProxyFCGIBackendType GENERIC"
+				print "            SetHandler \"proxy:unix:/run/php/" socket "|fcgi://localhost/\""
+				print "        </FilesMatch>"
+				done = 1
+			}
+		' "$onevhost" > "$onevhost.tmp" && mv "$onevhost.tmp" "$onevhost"
+		sed -i 's/^\([[:space:]]*\)php_admin_value open_basedir/\1#php_admin_value open_basedir/' "$onevhost"
+	fi
+done <<< "$apacheconfs"
+
+# Grant www-data read+traverse on htdocs (needed if/when this server later drops mpm_itk
+# for HTTP/2 - harmless additive ACL, itk already has full access via the socket owner).
+if command -v setfacl >/dev/null 2>&1; then
+	grandparent=$(dirname "$instancedir")
+	setfacl -m g:www-data:--x "$grandparent" 2>/dev/null || true
+	setfacl -m g:www-data:--x "$instancedir" 2>/dev/null || true
+	setfacl -R -m g:www-data:rX "$instancedir/htdocs" 2>/dev/null || true
+	setfacl -d -m g:www-data:rX "$instancedir/htdocs" 2>/dev/null || true
+fi
+
+apache2ctl configtest
+service apache2 reload
+
+# Stop/remove every OTHER existing php-fpm service for this instance, not just the one detected
+# from the live vhost's SetHandler above: that detection reads as "mod_php, nothing to stop" when
+# the current vhost has no SetHandler at all (eg. the suspended/maintenance templates, which only
+# redirect and were never meant to carry one), silently leaving the real previous-version service
+# (created at the original deploy or an earlier switch) running and orphaned instead of being
+# replaced. List actual services on disk instead of trusting the vhost content for this part.
+for oldsvc in $(ls /etc/systemd/system/sellyoursaas-php*-fpm-"$fqn".service 2>/dev/null); do
+	oldphpfpmservicename=$(basename "$oldsvc")
+	[[ "$oldphpfpmservicename" == "sellyoursaas-php$phpversion-fpm-$fqn.service" ]] && continue
+	oldphpver=$(echo "$oldphpfpmservicename" | sed -E "s/^sellyoursaas-php([0-9]+\.[0-9]+)-fpm-.*/\1/")
+	echo "$(date +'%Y-%m-%d %H:%M:%S') Stop and remove old php fpm pool/service for previous version $oldphpver"
+	systemctl disable --now "$oldphpfpmservicename" 2>/dev/null
+	rm -f "/etc/systemd/system/$oldphpfpmservicename"
+	rm -f "/etc/php/$oldphpver/fpm/pool.d/sellyoursaas/$fqn.phpfpm.conf"
+done
+systemctl daemon-reload
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') Updating the 'PHP version' contract field on the master server to match"
+# When this script is called from the CONTRACT_MODIFY trigger (the normal UI path), Dolibarr's
+# own updateExtraField() already wrote this same value to this same row *before* firing the
+# trigger, inside a transaction it only commits after this whole remote action returns - so this
+# UPDATE is racing its own caller for a lock it cannot win until the caller gives up and commits.
+# Fail fast (a handful of seconds, not the default 50s) instead of retrying blindly, and treat a
+# lock timeout as fine as long as the value already matches - it only ever needs to actually win
+# the race when this script is run standalone from the CLI, with no such caller/lock involved.
+masterupdateok=0
+for i in 1 2; do
+	if mastermysql "SET SESSION innodb_lock_wait_timeout=5; UPDATE ${dbprefix}contrat_extrafields ce JOIN ${dbprefix}contrat c ON c.rowid = ce.fk_object SET ce.phpversion = '$phpversion' WHERE c.ref_customer = '$fqn'"; then
+		masterupdateok=1
+		break
+	fi
+	echo "Warning: failed to update the 'PHP version' contract field (attempt $i/2), retrying in 2s" 1>&2
+	sleep 2
+done
+if [[ "$masterupdateok" != "1" ]]; then
+	currentvalue=$(mastermysql "SELECT ce.phpversion FROM ${dbprefix}contrat_extrafields ce JOIN ${dbprefix}contrat c ON c.rowid = ce.fk_object WHERE c.ref_customer = '$fqn'" 2>/dev/null | tail -n1)
+	if [[ "$currentvalue" == "$phpversion" ]]; then
+		echo "$(date +'%Y-%m-%d %H:%M:%S') Could not get the lock to update the 'PHP version' contract field, but it already reads '$phpversion' (most likely already set by the caller before triggering this action) - nothing more to do"
+	else
+		echo "Error: could not update the 'PHP version' contract field on the master server (currently '$currentvalue', expected '$phpversion') - the instance itself is now correctly running $phpversion, but the contract record is stale and needs a manual or retried update" 1>&2
+		exit 1
+	fi
+fi
+
+echo "$(date +'%Y-%m-%d %H:%M:%S') PHP version switch for $fqn to $phpversion done"

--- a/scripts/templates/phppool-phpfpm.template
+++ b/scripts/templates/phppool-phpfpm.template
@@ -12,7 +12,8 @@ group = __osGroupname__
 
 listen = /run/php/php__phpversion__-fpm-__fqn__.sock
 listen.owner = __osUsername__
-listen.group = __osGroupname__
+listen.group = www-data
+listen.mode = 0660
 request_terminate_timeout = 0
 
 pm = dynamic
@@ -22,8 +23,11 @@ pm.min_spare_servers = 5
 pm.max_spare_servers = 35
 
 env[PATH] = /usr/local/bin:/usr/bin:/bin
-env[TMP] = /tmp
-env[TMPDIR] = /tmp
-env[TEMP] = /tmp
+env[TMP] = __webAppPath__/tmp
+env[TMPDIR] = __webAppPath__/tmp
+env[TEMP] = __webAppPath__/tmp
 
-php_admin_value[open_basedir] = __webAppPath__:/home/admin/wwwroot/dolibarr_sellyoursaas/scripts/:/tmp/:/usr/local/bin/
+php_admin_value[sys_temp_dir] = __webAppPath__/tmp
+php_admin_value[upload_tmp_dir] = __webAppPath__/tmp
+
+php_admin_value[open_basedir] = __webAppPath__:__sellyoursaasScriptsPath__:/tmp/:/usr/local/bin/

--- a/scripts/templates/vhostHttps-phpfpm-sellyoursaas-dolibarrwebsite.template
+++ b/scripts/templates/vhostHttps-phpfpm-sellyoursaas-dolibarrwebsite.template
@@ -1,19 +1,23 @@
-# This wirtual host is used only to deploy a website build by the Dolibarr CMS of a Dolibarr customer instance
+# This virtual host is used only to deploy a website build by the Dolibarr CMS of a Dolibarr customer instance
 <VirtualHost *:443 *:80>
 
         <IfModule mod_apparmor.c>
         AADefaultHatName sellyoursaas-instances
         </IfModule>
 
-        # Allow access to /tmp and sellyoursaas scripts for mails. Allow also access to user dir.
-        php_admin_value open_basedir /tmp/:__sellyoursaasScriptsPath__:__osUserPath__/:/usr/local/bin/:/dev/urandom
+        # Indiquer à Apache d'utiliser le socket de PHP-FPM de l'instance (même pool que le
+        # site principal : ce vhost sert seulement un autre DocumentRoot de la même instance)
+        <FilesMatch \.php$>
+            ProxyFCGIBackendType GENERIC
+            SetHandler "proxy:unix:/run/php/php__phpversion__-fpm-__fqn__.sock|fcgi://localhost/"
+        </FilesMatch>
 
         # MaxRequestWorkers = MaxClients
         # MaxClientsVHost is for vhost/itk only
         #MaxClientsVHost 50
         #RLimitMEM 100000000
         #RLimitNProc 50
-        
+
         ServerName __webSiteDomain__
         ServerAdmin __webAdminEmail__
         ServerAlias __webSiteAliases__
@@ -74,8 +78,8 @@
         RewriteEngine On
         RewriteCond %{HTTP_HOST} !^www\. [NC]
         RewriteRule ^(.*)$ %{REQUEST_SCHEME}://www.%{HTTP_HOST}$1 [R=301,L]
-        
-        
+
+
         #SSLProxyEngine on
         # Use ProxyPass
         #ProxyPass /public https://__instanceName__.__domainName__/public
@@ -84,12 +88,12 @@
         # or use RewriteCond/Rule with [P] flag
         #RewriteCond %{HTTP_HOST} ^public\. [NC]
         #RewriteRule "(.*)$" "https://testldr4.with4.dolicloud.com/$1" [P]
-        
+
 		<IfFile "/home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/__instanceName__.__domainName__-__webSiteDomain__.crt">
 	        #   SSL Engine Switch:
 	        #   Enable/Disable SSL for this virtual host.
 	        SSLEngine on
-	
+
 	        #RewriteCond %{HTTPS} !=on
 	        # This checks to make sure the connection is not already HTTPS
 		    #RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
@@ -97,7 +101,7 @@
 	        # i.e.  http://www.example.com/foo/ to https://www.example.com/foo/
 	        # The leading slash is made optional so that this will work either in httpd.conf
 	        # or .htaccess context
-	
+
 	        SSLCertificateFile /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/__instanceName__.__domainName__-__webSiteDomain__.crt
 	        SSLCertificateKeyFile /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/__instanceName__.__domainName__-__webSiteDomain__.key
 	        SSLCertificateChainFile /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/__instanceName__.__domainName__-__webSiteDomain__-intermediate.crt
@@ -105,5 +109,3 @@
         </IfFile>
 
 </VirtualHost>
-     
-        

--- a/scripts/templates/vhostHttps-phpfpm-sellyoursaas-dolibarrwebsite.template
+++ b/scripts/templates/vhostHttps-phpfpm-sellyoursaas-dolibarrwebsite.template
@@ -89,7 +89,7 @@
         #RewriteCond %{HTTP_HOST} ^public\. [NC]
         #RewriteRule "(.*)$" "https://testldr4.with4.dolicloud.com/$1" [P]
 
-		<IfFile "/home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/__instanceName__.__domainName__-__webSiteDomain__.crt">
+		<IfFile "__sellyoursaasLocalCrtPath__/__instanceName__.__domainName__-__webSiteDomain__.crt">
 	        #   SSL Engine Switch:
 	        #   Enable/Disable SSL for this virtual host.
 	        SSLEngine on
@@ -102,10 +102,10 @@
 	        # The leading slash is made optional so that this will work either in httpd.conf
 	        # or .htaccess context
 
-	        SSLCertificateFile /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/__instanceName__.__domainName__-__webSiteDomain__.crt
-	        SSLCertificateKeyFile /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/__instanceName__.__domainName__-__webSiteDomain__.key
-	        SSLCertificateChainFile /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/__instanceName__.__domainName__-__webSiteDomain__-intermediate.crt
-	        SSLCACertificateFile /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/__instanceName__.__domainName__-__webSiteDomain__-intermediate.crt
+	        SSLCertificateFile __sellyoursaasLocalCrtPath__/__instanceName__.__domainName__-__webSiteDomain__.crt
+	        SSLCertificateKeyFile __sellyoursaasLocalCrtPath__/__instanceName__.__domainName__-__webSiteDomain__.key
+	        SSLCertificateChainFile __sellyoursaasLocalCrtPath__/__instanceName__.__domainName__-__webSiteDomain__-intermediate.crt
+	        SSLCACertificateFile __sellyoursaasLocalCrtPath__/__instanceName__.__domainName__-__webSiteDomain__-intermediate.crt
         </IfFile>
 
 </VirtualHost>

--- a/scripts/templates/vhostHttps-sellyoursaas-maintenance.template
+++ b/scripts/templates/vhostHttps-sellyoursaas-maintenance.template
@@ -1,8 +1,8 @@
 <VirtualHost *:443 *:80>
         __VirtualHostHead__
-
-        # Allow access to /tmp and sellyoursaas scripts for mails. Allow also access to user dir webAppPath.
-        php_admin_value open_basedir /tmp/:/home/admin/wwwroot/dolibarr_sellyoursaas/scripts/:__webAppPath__/:/usr/local/bin/
+        
+        # Allow access to /tmp and sellyoursaas scripts for mails. Allow also access to user dir.
+        php_admin_value open_basedir /tmp/:__sellyoursaasScriptsPath__:__webAppPath__/:/usr/local/bin/
 
         ServerName __webAppDomain__
         ServerAdmin __webAdminEmail__
@@ -27,7 +27,7 @@
 
         ErrorLog /var/log/apache2/apache_sellyoursaas_maintenance_error.log
         #TransferLog /var/log/apache2/__webAppLogName___access.log
-
+        
         # Compress returned resources of type php pages, text file export, css and javascript
         AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css text/javascript application/javascript application/x-javascript
 
@@ -57,7 +57,7 @@
 
         RewriteEngine   on
         # This will enable the Rewrite capabilities
-
+        
         RewriteCond     "%{HTTP_USER_AGENT}"   "!__SELLYOURSAAS_LOGIN_FOR_SUPPORT__"
         RewriteRule     ^(.*)$ __webMyAccount__/maintenance.php?instance=%{SERVER_NAME} [L,R]
 		# This redirect to the maintenance page
@@ -76,3 +76,6 @@ SSLCertificateChainFile /etc/apache2/__webSSLCertificateIntermediate__
 SSLCACertificateFile /etc/apache2/__webSSLCertificateIntermediate__
 
 </VirtualHost>
+
+
+

--- a/scripts/templates/vhostHttps-sellyoursaas-suspended.template
+++ b/scripts/templates/vhostHttps-sellyoursaas-suspended.template
@@ -2,7 +2,7 @@
         __VirtualHostHead__
         
         # Allow access to /tmp and sellyoursaas scripts for mails. Allow also access to user dir.
-        php_admin_value open_basedir /tmp/:/home/admin/wwwroot/dolibarr_sellyoursaas/scripts/:__webAppPath__/:/usr/local/bin/
+        php_admin_value open_basedir /tmp/:__sellyoursaasScriptsPath__:__webAppPath__/:/usr/local/bin/
 
         ServerName __webAppDomain__
         ServerAdmin __webAdminEmail__

--- a/scripts/templates/vhostHttps-sellyoursaas.template
+++ b/scripts/templates/vhostHttps-sellyoursaas.template
@@ -1,13 +1,13 @@
 <VirtualHost *:80>
         __VirtualHostHead__
-
+        
         <IfModule mod_apparmor.c>
         AADefaultHatName sellyoursaas-instances
         </IfModule>
-
+        
         # Allow access to /tmp and sellyoursaas scripts for mails. Allow also access to user dir.
-        php_admin_value open_basedir /tmp/:/home/admin/wwwroot/dolibarr_sellyoursaas/scripts/:__webAppPath__/:/usr/local/bin/
-
+        php_admin_value open_basedir /tmp/:__sellyoursaasScriptsPath__:__webAppPath__/:/usr/local/bin/
+        
         ServerName __webAppDomain__
         ServerAdmin __webAdminEmail__
         ServerAlias __webAppAliases__
@@ -25,7 +25,7 @@
         </IfModule>
 
 		# __ AllowOverride __ is defined on package.
-		# __ IncludeFromContract __ is defined on contract.
+		# __ IncludeFromContract __ is defined on contract. 
 		# For example: "Require ip 1.2.3.4"
 		# or "IncludeOptional /etc/apache2/sellyoursaas-online/__webAppDomain__-directory-options.conf"
         <Directory "__webAppPath__/htdocs">
@@ -34,7 +34,7 @@
         Require all granted
         __IncludeFromContract__
         </RequireAll>
-
+        
         Options -Indexes +FollowSymLinks
         </Directory>
 
@@ -69,10 +69,10 @@
 
         RewriteEngine On
         # This will enable the Rewrite capabilities
-
+		
         RewriteCond %{HTTPS} !=on
         # This checks to make sure the connection is not already HTTPS
-
+		
         RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
         # This rule will redirect users from their original location, to the same location but using HTTPS.
         # i.e.  http://www.example.com/foo/ to https://www.example.com/foo/
@@ -92,14 +92,14 @@
 
 <VirtualHost *:443>
         __VirtualHostHead__
-
+        
         <IfModule mod_apparmor.c>
         AADefaultHatName sellyoursaas-instances
         </IfModule>
-
+        
         # Allow access to /tmp and sellyoursaas scripts for mails. Allow also access to user dir.
-        php_admin_value open_basedir /tmp/:/home/admin/wwwroot/dolibarr_sellyoursaas/scripts/:__webAppPath__/:/usr/local/bin/
-
+        php_admin_value open_basedir /tmp/:__sellyoursaasScriptsPath__:__webAppPath__/:/usr/local/bin/
+        
         ServerName __webAppDomain__
         ServerAdmin __webAdminEmail__
         ServerAlias __webAppAliases__
@@ -117,7 +117,7 @@
         </IfModule>
 
 		# __ AllowOverride __ is defined on package.
-		# __ IncludeFromContract __ is defined on contract.
+		# __ IncludeFromContract __ is defined on contract. 
 		# For example: "Require ip 1.2.3.4"
 		# or "IncludeOptional /etc/apache2/sellyoursaas-online/__webAppDomain__-directory-options.conf"
         <Directory "__webAppPath__/htdocs">
@@ -126,7 +126,7 @@
         Require all granted
         __IncludeFromContract__
         </RequireAll>
-
+        
         Options -Indexes +FollowSymLinks
         </Directory>
 
@@ -163,7 +163,7 @@
         #   Enable/Disable SSL for this virtual host.
         SSLEngine on
 
-
+		
         RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
         # This rule will redirect users from their original location, to the same location but using HTTPS.
         # i.e.  http://www.example.com/foo/ to https://www.example.com/foo/
@@ -185,12 +185,17 @@
 		SSLCACertificateFile /etc/apache2/__webSSLCertificateIntermediate__
 
 
-		# This section can be removed, the SSL certificate is already set previously (to the custom certificate for custom virtual host or to the generic one for standard virtual host or if custom cert not found).
+		# To enable this section, you must edit /etc/apache2/envvars to set 
+		# export APACHE_ARGUMENTS='-DUSEIFFILE'
+		# You can do it only if Apache is 2.4.35+
+		# This section can be removed, the SSL certificate is already set previously (to the custom certiticate for custom virtual host or to the generic one for standard virtual host or if custom cert not found).
+		#<IfDefine USEIFFILE>
         #<IfFile "/home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/__webAppDomain__.crt">
 		#	SSLCertificateFile /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/__webAppDomain__.crt
 		#	SSLCertificateKeyFile /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/__webAppDomain__.key
 		#	SSLCertificateChainFile /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/__webAppDomain__-intermediate.crt
 		#	SSLCACertificateFile /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/__webAppDomain__-intermediate.crt
         #</IfFile>
+        #</IfDefine>
 
 </VirtualHost>


### PR DESCRIPTION
This is 2/3 of the staged split of #491 requested by @eldy - deploy/suspend/undeploy lifecycle integration, built on top of #501 (1/3, server-prep scripts). Since #501 isn't merged yet, this diff includes its content too; the new work here is the last 6 files/commit on top of it.

Wires the per-instance PHP version override through the remote agent's lifecycle actions:

- `action_deploy_undeploy.sh`, `action_suspend_unsuspend.sh`, `action_website_instance.sh`: honor an explicit per-instance PHP version (new param) instead of always using the server's default from `/etc/sellyoursaas.conf`, and undeploy now removes the instance's php-fpm pool conf and systemd unit files instead of only stopping them.
- `action_customurl_instance.sh`: substitute `__phpversion__`/`__fqn__` when generating a custom-URL vhost on a php-fpm server (was left as literal placeholders, breaking the vhost), and add a new `changephpversion` mode that hands off to `switch_instance_phpversion.sh`.
- `remote_server/index.php`: dispatch the new `changephpversion` action.
- New `vhostHttps-phpfpm-sellyoursaas-dolibarrwebsite.template`: phpfpm-aware variant of the Dolibarr-CMS website vhost template, proxying to the instance's own FPM socket instead of the mod_php open_basedir directive.

No Dolibarr UI/data-model changes - that's #504 (3/3).

**On testing**: the underlying flow (contract PhpVersion field -> CONTRACT_MODIFY trigger -> changephpversion remote action -> switch_instance_phpversion.sh) was already tested end-to-end on a real server through the normal Dolibarr UI, before this PR split - that's what the robustness fixes already on `switch_instance_phpversion.sh` (retry logic, stale service cleanup) came from. This PR reconstructs the plumbing around that same tested design on top of #501's current code, since the original combined branch had since diverged. Syntax-checked (`bash -n`) but this reconstruction itself hasn't been re-run live since the split - left as draft until it is.