### PR TITLE
Re-grant www-data ACL on htdocs after a core upgrade, in both upgrade paths

### DIFF
--- a/scripts/action_upgrade_instance.sh
+++ b/scripts/action_upgrade_instance.sh
@@ -368,6 +368,21 @@ if [[ "$mode" == "upgrade" ]];then
 		echo `date +'%Y-%m-%d %H:%M:%S'`" chmod -R go-rwxs $targetdir/$osusername/$dbname"
 		chmod -R go-rwxs $targetdir/$osusername/$dbname
 
+		# Grant the web server group read+traverse on htdocs only (never on documents/, which is
+		# only ever reached through an authenticated PHP script running under the instance's own
+		# php-fpm pool user). This keeps htdocs servable by Apache whether the server still uses
+		# mpm_itk (harmless, itk already gives full access) or has moved to mpm_event for HTTP/2
+		# (where Apache itself runs as a single shared user and needs this ACL to serve static files).
+		if command -v setfacl >/dev/null 2>&1; then
+			echo `date +'%Y-%m-%d %H:%M:%S'`" Grant www-data traverse-only on the instance directories and read+traverse on htdocs"
+			setfacl -m g:www-data:--x "$targetdir/$osusername"
+			setfacl -m g:www-data:--x "$targetdir/$osusername/$dbname"
+			setfacl -R -m g:www-data:rX "$targetdir/$osusername/$dbname/htdocs"
+			setfacl -d -m g:www-data:rX "$targetdir/$osusername/$dbname/htdocs"
+		else
+			echo `date +'%Y-%m-%d %H:%M:%S'`" Warning: setfacl not found (acl package not installed), skipping www-data ACL on htdocs - static files will only be servable while this server still uses mpm_itk"
+		fi
+
 		echo `date +'%Y-%m-%d %H:%M:%S'`" cd $instancedir/"
         cd $instancedir/
 

--- a/scripts/rsync_instance.php
+++ b/scripts/rsync_instance.php
@@ -313,6 +313,39 @@ foreach ($output as $outputline) {
 	print $outputline."\n";
 }
 
+// Grant the web server group read+traverse on htdocs only (never on documents/, which is
+// only ever reached through an authenticated PHP script running under the instance's own
+// php-fpm pool user). This keeps htdocs servable by Apache whether the server still uses
+// mpm_itk (harmless, itk already gives full access) or has moved to mpm_event for HTTP/2
+// (where Apache itself runs as a single shared user and needs this ACL to serve static files).
+// Must be redone after every sync since rsync (-rlt, no -a/-p) doesn't preserve permissions/ACLs
+// from the source. Same pattern as used in action_deploy_undeploy.sh/action_upgrade_instance.sh,
+// except using the numeric GID (33) rather than the "www-data" name: unlike those two scripts,
+// this one runs the command over SSH as the instance's own jailed OS user (setfacl needs setfacl
+// itself present in the jail, and the jail's own /etc/group has no www-data entry to resolve the
+// name against, even though the same GID exists and resolves fine on the real host outside the
+// jail).
+if (in_array($mode, array('confirm', 'confirmunlock', 'confirmwithtestdir', 'confirmclean'))) {
+	$aclcommand = "if command -v setfacl >/dev/null 2>&1; then "
+		."setfacl -m g:33:--x ".escapeshellarg(dirname($targetdir))." ; "
+		."setfacl -m g:33:--x ".escapeshellarg($targetdir)." ; "
+		."setfacl -R -m g:33:rX ".escapeshellarg($targetdir.'/htdocs')." ; "
+		."setfacl -d -m g:33:rX ".escapeshellarg($targetdir.'/htdocs')." ; "
+		."echo 'ACL grant done'; "
+		."else echo 'Warning: setfacl not found (acl package not installed), skipping www-data ACL on htdocs - static files will only be servable while this server still uses mpm_itk'; fi";
+	$sshaclcommand = "ssh -p ".$server_port." -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no "
+		.$login.'@'.$server." ".escapeshellarg($aclcommand);
+
+	print "Grant www-data ACL on htdocs so Apache can serve static assets directly (php-fpm/mpm_event servers)\n";
+	print $sshaclcommand."\n";
+	$acloutput = array();
+	$aclreturn = 0;
+	exec($sshaclcommand, $acloutput, $aclreturn);
+	foreach ($acloutput as $outputline) {
+		print $outputline."\n";
+	}
+}
+
 // Remove install.lock and create upgrade.unlock file if mode confirmunlock
 if ($mode == 'confirmunlock') {
 	// SFTP connect

--- a/scripts/rsync_instance.php
+++ b/scripts/rsync_instance.php
@@ -320,17 +320,20 @@ foreach ($output as $outputline) {
 // (where Apache itself runs as a single shared user and needs this ACL to serve static files).
 // Must be redone after every sync since rsync (-rlt, no -a/-p) doesn't preserve permissions/ACLs
 // from the source. Same pattern as used in action_deploy_undeploy.sh/action_upgrade_instance.sh,
-// except using the numeric GID (33) rather than the "www-data" name: unlike those two scripts,
-// this one runs the command over SSH as the instance's own jailed OS user (setfacl needs setfacl
-// itself present in the jail, and the jail's own /etc/group has no www-data entry to resolve the
-// name against, even though the same GID exists and resolves fine on the real host outside the
-// jail).
+// except using the numeric GID rather than the "www-data" name: unlike those two scripts, this
+// one runs the command over SSH as the instance's own jailed OS user (the jail's own /etc/group
+// has no www-data entry to resolve the name against, even though the same GID exists and resolves
+// fine on the real host outside the jail) - so resolve the GID here, on the real host, instead of
+// assuming it's always 33 (true on stock Debian/Ubuntu today, but not guaranteed on every system).
 if (in_array($mode, array('confirm', 'confirmunlock', 'confirmwithtestdir', 'confirmclean'))) {
+	$webservergroupinfo = posix_getgrnam('www-data');
+	$webservergroupid = ($webservergroupinfo !== false) ? $webservergroupinfo['gid'] : 33;
+
 	$aclcommand = "if command -v setfacl >/dev/null 2>&1; then "
-		."setfacl -m g:33:--x ".escapeshellarg(dirname($targetdir))." ; "
-		."setfacl -m g:33:--x ".escapeshellarg($targetdir)." ; "
-		."setfacl -R -m g:33:rX ".escapeshellarg($targetdir.'/htdocs')." ; "
-		."setfacl -d -m g:33:rX ".escapeshellarg($targetdir.'/htdocs')." ; "
+		."setfacl -m g:".$webservergroupid.":--x ".escapeshellarg(dirname($targetdir))." ; "
+		."setfacl -m g:".$webservergroupid.":--x ".escapeshellarg($targetdir)." ; "
+		."setfacl -R -m g:".$webservergroupid.":rX ".escapeshellarg($targetdir.'/htdocs')." ; "
+		."setfacl -d -m g:".$webservergroupid.":rX ".escapeshellarg($targetdir.'/htdocs')." ; "
 		."echo 'ACL grant done'; "
 		."else echo 'Warning: setfacl not found (acl package not installed), skipping www-data ACL on htdocs - static files will only be servable while this server still uses mpm_itk'; fi";
 	$sshaclcommand = "ssh -p ".$server_port." -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no "


### PR DESCRIPTION
## Context
`action_deploy_undeploy.sh` (deploy), `action_after_instance.sh` (cliafter/cliafterdeployoption), `switch_instance_phpversion.sh` and `migrate_server_http2.sh` already re-grant the `www-data` ACL on an instance's `htdocs/` after touching its files - needed on any server running `mpm_event`/php-fpm instead of `mpm_itk`, since Apache then runs as a single shared user with no other way to read files otherwise locked to the instance's own OS user.

`action_upgrade_instance.sh` - what the "Upgrade now" button in the backoffice actually calls - was missing this entirely, so every routine core upgrade silently regressed the ACL grant made at deploy time on any `mpm_event`/php-fpm server, until whoever hit it there noticed 403s on core static assets (`theme/`, `install/`, etc).

`rsync_instance.php` (the manual CLI alternative to the same upgrade) never preserved permissions/ACLs from the source at all (uses `-rlt`, not `-a`/`-p`) and had the same gap, plus its own extra wrinkle: it runs the fix-up command over SSH as the instance's own jailed OS user, where `setfacl` can't resolve the `www-data` *name* (the jail's own `/etc/group` has no such entry) even once the `setfacl` binary itself is present in the jail - uses the numeric GID (`33`) there instead, which resolves fine since it's the same GID on the real host.

## What's included
- `action_upgrade_instance.sh`: re-grant the same ACL block (`setfacl -R -m g:www-data:rX` + default ACL) right after the existing `chmod -R go-rwxs`, matching the other four scripts.
- `rsync_instance.php`: same fix, adapted for running over SSH as the jailed instance user (numeric GID, gated on the real write modes only).

## Test plan
- [x] `bash -n` on `action_upgrade_instance.sh`
- [x] Tested live this session against a real instance stuck in this exact state (403 on `theme/dolibarr_logo.svg` and `install/default.css` under the maintenance-mode support bypass) - both fixes verified end to end, including the jailkit-specific numeric-GID issue for `rsync_instance.php` (confirmed via a live `setfacl` test inside the jail before landing on the GID fix)

## Independent of #499/#501/#503/#504
This PR doesn't touch any file those four modify (`action_upgrade_instance.sh` and `rsync_instance.php` are untouched by all of them) - safe to merge in any order relative to them.