### PR TITLE
Fix remote agent: signature at fixed offset breaks shorter param lists, cwd not guaranteed after systemd restart

### DIFF
--- a/doc/Documentation SellYourSaas - Master and Deployment Servers - EN.asciidoc
+++ b/doc/Documentation SellYourSaas - Master and Deployment Servers - EN.asciidoc
@@ -1515,6 +1515,29 @@ systemctl status remote_server_launcher
 
 Note: The agent is launched on port 8080 and is waiting master orders.
 
+Note: *remote_server_launcher* (this file) and the *scripts/remote_server/index.php* it serves
+should instead be **local, non-mounted copies** under */etc/init.d/* (not the symlink above),
+so the agent can still be started/restarted and report its own status even if *dolibarrdir=*
+(in */etc/sellyoursaas.conf*) lives on a separate mount that is temporarily down - only the
+action_*.sh scripts it calls, which genuinely only exist there, would then fail explicitly.
+*remote_server_launcher.sh* still `cd`s into the real (mounted) scripts directory before starting
+`php -S`, and *index.php* itself also `chdir()`s there on every request as a safety net, in case
+the cwd set by the launcher does not survive however the init system forks/daemonizes the process
+(observed to not survive on some systemd-wrapped LSB service starts).
+
+Since the launcher no longer needs the mount just to be read/executed, nothing else forces
+systemd to wait for it at boot - if *dolibarrdir=* is on a separate mount, add a drop-in so the
+service still starts in the right order (replace */mnt/example* with that mount point):
+
+[source, bash]
+---------------
+mkdir -p /etc/systemd/system/remote_server_launcher.service.d
+cat > /etc/systemd/system/remote_server_launcher.service.d/mount-order.conf << 'EOF'
+[Unit]
+RequiresMountsFor=/mnt/example
+EOF
+systemctl daemon-reload
+---------------
 
 To use systemd create a file */etc/systemd/system/remote-server-launcher.service* :
 

--- a/scripts/remote_server/index.php
+++ b/scripts/remote_server/index.php
@@ -17,6 +17,7 @@ $signature_key = '';
 $dnsserver = '';
 $instanceserver = '';
 $backupdir = '';
+$dolibarrdir = '';
 
 // Read /etc/sellyoursaas.conf file
 $fp = @fopen('/etc/sellyoursaas.conf', 'r');
@@ -40,10 +41,22 @@ if ($fp) {
 		if ($tmpline[0] == 'backupdir') {
 			$backupdir = $tmpline[1];
 		}
+		if ($tmpline[0] == 'dolibarrdir') {
+			$dolibarrdir = $tmpline[1];
+		}
 	}
 } else {
 	print "Failed to open /etc/sellyoursaas.conf file\n";
 	exit;
+}
+
+// remote_server_launcher.sh already cd's into the mounted scripts directory before starting
+// php -S, but that only holds if it survives however the init/service manager forks and
+// daemonizes the process (observed to NOT survive a systemd-wrapped LSB service start/restart,
+// leaving this process's cwd at whatever systemd's default WorkingDirectory is instead) - so
+// set it here too, unconditionally, rather than relying on the launcher alone.
+if (!empty($dolibarrdir)) {
+	@chdir($dolibarrdir.'/custom/sellyoursaas/scripts');
 }
 //if (! in_array('127.0.0.1', $allowed_hosts_array)) {
 //	$allowed_hosts_array[] = '127.0.0.1';	// Add localhost if not present
@@ -92,7 +105,12 @@ $dbusername = $tmpparam[6];
 $cliafter = $tmpparam[18];
 $cliafterpaid = $tmpparam[46];
 $cliafterdeployoption = $tmpparam[47];
-$signature = empty($tmpparam[48]) ? '' : $tmpparam[48];		// Extract the signature received
+// The signature is always the last parameter appended by the caller (see sellyoursaasRemoteAction()),
+// whatever the total number of parameters sent for this action. preg_split() leaves a trailing empty
+// element because paramspacenoquotes always ends with a separator space, so the signature is the
+// element right before that one.
+$signatureindex = count($tmpparam) - 2;
+$signature = ($signatureindex >= 0 && !empty($tmpparam[$signatureindex])) ? $tmpparam[$signatureindex] : '';
 
 // Recalculate the signature with message received
 // TODO Replace with hash('sha256', $contentsigned.$signature_key); or use asymmetric signature.

--- a/scripts/remote_server/index.php
+++ b/scripts/remote_server/index.php
@@ -56,7 +56,7 @@ if ($fp) {
 // leaving this process's cwd at whatever systemd's default WorkingDirectory is instead) - so
 // set it here too, unconditionally, rather than relying on the launcher alone.
 if (!empty($dolibarrdir)) {
-	@chdir($dolibarrdir.'/custom/sellyoursaas/scripts');
+	@chdir($dolibarrdir.'/htdocs/custom/sellyoursaas/scripts');
 }
 //if (! in_array('127.0.0.1', $allowed_hosts_array)) {
 //	$allowed_hosts_array[] = '127.0.0.1';	// Add localhost if not present


### PR DESCRIPTION
Split out from #496 per @eldy's review comment (unrelated to the custom-URL SSL fix there).

- `scripts/remote_server/index.php`: the signature was read from a fixed position (index 48), which breaks for actions with a shorter parameter list (e.g. a read-only, no-credentials action). Read it as the second-to-last element instead (`paramspacenoquotes` always ends with a trailing separator, leaving one empty element after it, so the signature is the element right before that one) - this keeps working regardless of how many parameters a given action sends.
- Also `chdir()` into `dolibarrdir/custom/sellyoursaas/scripts` unconditionally on every request, as a safety net: `remote_server_launcher.sh` already `cd`s there before starting `php -S`, but that cwd is not guaranteed to survive however the init system forks/daemonizes the process (observed to not survive some systemd-wrapped LSB service starts/restarts).
- doc: note that `remote_server_launcher` + `index.php` should be local, non-mounted copies (so the agent can still start/report status even if `dolibarrdir` is on a temporarily-down separate mount), with the systemd `RequiresMountsFor` drop-in needed if that mount ordering matters.