### PR TITLE
Fix hardcoded SSL cert path for the website (secondary domain) feature

### DIFF
--- a/scripts/action_website_instance.sh
+++ b/scripts/action_website_instance.sh
@@ -171,6 +171,8 @@ if [[ "x$olddoldataroot" != "x" && "x$newdoldataroot" != "x" ]]; then
 	cliafter=${cliafter/$olddoldataroot/$newdoldataroot}
 fi
 
+export pathforcertiflocal="${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt"
+
 # For debug
 echo `date +'%Y-%m-%d %H:%M:%S'`" input params for $0:"
 echo "mode = $mode"
@@ -241,7 +243,8 @@ if [[ "$mode" == "deploywebsite" ]]; then
 			  sed -e 's;__SELLYOURSAAS_LOGIN_FOR_SUPPORT__;$SELLYOURSAAS_LOGIN_FOR_SUPPORT;g' | \
 			  sed -e 's;#ErrorLog;$ErrorLog;g' | \
 			  sed -e 's;__webMyAccount__;$SELLYOURSAAS_ACCOUNT_URL;g' | \
-			  sed -e 's;__webAppPath__;$instancedir;g' > $apacheconf"
+			  sed -e 's;__webAppPath__;$instancedir;g' | \
+			  sed -e 's;__sellyoursaasLocalCrtPath__;$pathforcertiflocal;g' > $apacheconf"
 	cat $vhostfilewebsite | sed -e "s/__webSiteDomain__/$CUSTOMDOMAIN/g" | \
 			  sed -e "s/__webSiteAliases__/$CUSTOMDOMAIN www.$CUSTOMDOMAIN/g" | \
 			  sed -e "s/__webSiteNamePath__/$WEBSITENAME/g" | \
@@ -261,7 +264,8 @@ if [[ "$mode" == "deploywebsite" ]]; then
 			  sed -e "s;__SELLYOURSAAS_LOGIN_FOR_SUPPORT__;$SELLYOURSAAS_LOGIN_FOR_SUPPORT;g" | \
 			  sed -e "s;#ErrorLog;$ErrorLog;g" | \
 			  sed -e "s;__webMyAccount__;$SELLYOURSAAS_ACCOUNT_URL;g" | \
-			  sed -e "s;__webAppPath__;$instancedir;g" > $apacheconf
+			  sed -e "s;__webAppPath__;$instancedir;g" | \
+			  sed -e "s;__sellyoursaasLocalCrtPath__;$pathforcertiflocal;g" > $apacheconf
 	export vhostko=$?
 
 	echo `date +'%Y-%m-%d %H:%M:%S'`" Result of generation of file $apacheconf = $vhostko"
@@ -284,8 +288,8 @@ if [[ "$mode" == "deploywebsite" ]]; then
 	fi
 
 
-	echo "Create cert directory with mkdir /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/; chown admin:admin /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/;"
-	mkdir /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/; chown admin:admin /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/;
+	echo "Create cert directory with mkdir -p $pathforcertiflocal/; chown admin:admin $pathforcertiflocal/;"
+	mkdir -p $pathforcertiflocal/; chown admin:admin $pathforcertiflocal/;
 
 	if [[ ${46} == www.* ]]; then
 		echo certbot certonly -n -v --webroot -w $instancedir/documents/website/$WEBSITENAME -d www.$CUSTOMDOMAIN
@@ -301,13 +305,13 @@ if [[ "$mode" == "deploywebsite" ]]; then
 
 
 	echo "Link certificate for virtualhost with
-		ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/privkey.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$instancename.$domainname-$CUSTOMDOMAIN.key
-		ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/cert.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$instancename.$domainname-$CUSTOMDOMAIN.crt
-		ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/fullchain.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$instancename.$domainname-$CUSTOMDOMAIN-intermediate.crt
+		ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/privkey.pem $pathforcertiflocal/$instancename.$domainname-$CUSTOMDOMAIN.key
+		ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/cert.pem $pathforcertiflocal/$instancename.$domainname-$CUSTOMDOMAIN.crt
+		ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/fullchain.pem $pathforcertiflocal/$instancename.$domainname-$CUSTOMDOMAIN-intermediate.crt
 	"
-	ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/privkey.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$instancename.$domainname-$CUSTOMDOMAIN.key
-	ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/cert.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$instancename.$domainname-$CUSTOMDOMAIN.crt
-	ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/fullchain.pem /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/$instancename.$domainname-$CUSTOMDOMAIN-intermediate.crt
+	ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/privkey.pem $pathforcertiflocal/$instancename.$domainname-$CUSTOMDOMAIN.key
+	ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/cert.pem $pathforcertiflocal/$instancename.$domainname-$CUSTOMDOMAIN.crt
+	ln -fs /etc/letsencrypt/live/www.$CUSTOMDOMAIN/fullchain.pem $pathforcertiflocal/$instancename.$domainname-$CUSTOMDOMAIN-intermediate.crt
 
 
 	echo `date +'%Y-%m-%d %H:%M:%S'`" Restart apache to have the new certificate being loaded"

--- a/scripts/deployment_make_instances_relink_cert.sh
+++ b/scripts/deployment_make_instances_relink_cert.sh
@@ -10,11 +10,14 @@ export GREEN='\033[0;32m'
 export BLUE='\033[0;34m'
 export YELLOW='\033[0;33m'
 
+# possibility to change the path of sellyoursaas directory
+export newdoldataroot=`grep '^newdoldataroot=' /etc/sellyoursaas.conf | cut -d '=' -f 2`
+export pathforcertiflocal="${newdoldataroot:-/home/admin/wwwroot/dolibarr_documents}/sellyoursaas_local/crt"
 
 echo "***** $0 $1 $2 $3 *****"
 
 if [ "x$2" == "x" ]; then
-   echo "Relink local certificates found into /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt to link to the provided specific cert files."
+   echo "Relink local certificates found into $pathforcertiflocal to link to the provided specific cert files."
    echo "If local certificates are already links, nothing is done, only hard files are replaced by a link."
    echo
    echo "Usage:   $0  root_of_cert_to_link_to  regex_of_files_to_replace  test|confirm"
@@ -51,8 +54,8 @@ fi
 
 export scriptdir=$(dirname $(realpath ${0}))
 
-echo "Search local cert files to relink with: ls /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/*.key | grep $2"
-for fic in `ls /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/*.key | grep $2`
+echo "Search local cert files to relink with: ls $pathforcertiflocal/*.key | grep $2"
+for fic in `ls $pathforcertiflocal/*.key | grep $2`
 do
 	newfic="${fic%.key}"
 	echo "* Process files $newfic(.key|.crt|-intermediate.crt)"

--- a/scripts/templates/vhostHttps-sellyoursaas-dolibarrwebsite.template
+++ b/scripts/templates/vhostHttps-sellyoursaas-dolibarrwebsite.template
@@ -6,7 +6,7 @@
         </IfModule>
 
         # Allow access to /tmp and sellyoursaas scripts for mails. Allow also access to user dir.
-        php_admin_value open_basedir /tmp/:/home/admin/wwwroot/dolibarr_sellyoursaas/scripts/:__osUserPath__/:/usr/local/bin/:/dev/urandom
+        php_admin_value open_basedir /tmp/:__sellyoursaasScriptsPath__:__osUserPath__/:/usr/local/bin/:/dev/urandom
 
         # MaxRequestWorkers = MaxClients
         # MaxClientsVHost is for vhost/itk only
@@ -85,7 +85,7 @@
         #RewriteCond %{HTTP_HOST} ^public\. [NC]
         #RewriteRule "(.*)$" "https://testldr4.with4.dolicloud.com/$1" [P]
         
-		<IfFile "/home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/__instanceName__.__domainName__-__webSiteDomain__.crt">
+		<IfFile "__sellyoursaasLocalCrtPath__/__instanceName__.__domainName__-__webSiteDomain__.crt">
 	        #   SSL Engine Switch:
 	        #   Enable/Disable SSL for this virtual host.
 	        SSLEngine on
@@ -98,10 +98,10 @@
 	        # The leading slash is made optional so that this will work either in httpd.conf
 	        # or .htaccess context
 	
-	        SSLCertificateFile /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/__instanceName__.__domainName__-__webSiteDomain__.crt
-	        SSLCertificateKeyFile /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/__instanceName__.__domainName__-__webSiteDomain__.key
-	        SSLCertificateChainFile /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/__instanceName__.__domainName__-__webSiteDomain__-intermediate.crt
-	        SSLCACertificateFile /home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt/__instanceName__.__domainName__-__webSiteDomain__-intermediate.crt
+	        SSLCertificateFile __sellyoursaasLocalCrtPath__/__instanceName__.__domainName__-__webSiteDomain__.crt
+	        SSLCertificateKeyFile __sellyoursaasLocalCrtPath__/__instanceName__.__domainName__-__webSiteDomain__.key
+	        SSLCertificateChainFile __sellyoursaasLocalCrtPath__/__instanceName__.__domainName__-__webSiteDomain__-intermediate.crt
+	        SSLCACertificateFile __sellyoursaasLocalCrtPath__/__instanceName__.__domainName__-__webSiteDomain__-intermediate.crt
         </IfFile>
 
 </VirtualHost>


### PR DESCRIPTION
Same bug class as the custom-URL fix (already merged), for a different feature: the `vhostHttps-sellyoursaas-dolibarrwebsite.template` had the crt directory prefix baked directly into the template text instead of a substitutable placeholder, so it never followed `newdoldataroot` overrides.

- `scripts/templates/vhostHttps-sellyoursaas-dolibarrwebsite.template`: new `__sellyoursaasLocalCrtPath__` placeholder replacing the hardcoded `/home/admin/wwwroot/dolibarr_documents/sellyoursaas_local/crt` prefix (the filename part - `__instanceName__`/`__domainName__`/`__webSiteDomain__` - was already correctly substituted, only the directory prefix was static).
- `scripts/action_website_instance.sh`: resolve `pathforcertiflocal` via `newdoldataroot` (same pattern as `action_customurl_instance.sh`/`action_deploy_undeploy.sh`/`action_suspend_unsuspend.sh`), wire the new sed substitution, use it in the `mkdir`/`ln -fs` commands (also `mkdir -p` instead of `mkdir`, which failed on a missing parent).
- `scripts/deployment_make_instances_relink_cert.sh`: same `newdoldataroot` resolution, placed before the usage-message early exit so the printed path is correct there too.

Verified live before opening this PR: the sed pipeline produces the exact filename `action_website_instance.sh`'s own `ln -fs` commands create, and `deployment_make_instances_relink_cert.sh` resolves to a real instance server's actual `newdoldataroot` override (`/home/admin/documents` on 172.16.1.50), not just the fallback default.